### PR TITLE
do a fetch and hard reset instead of pull

### DIFF
--- a/src/main/java/org/testeditor/web/backend/testexecution/workspace/WorkspaceProvider.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/workspace/WorkspaceProvider.xtend
@@ -3,17 +3,31 @@ package org.testeditor.web.backend.testexecution.workspace
 import java.io.File
 import javax.inject.Inject
 import javax.inject.Provider
+import org.eclipse.jgit.lib.BranchConfig
+import org.slf4j.LoggerFactory
 import org.testeditor.web.backend.testexecution.dropwizard.GitConfiguration
 import org.testeditor.web.backend.testexecution.git.GitProvider
 
+import static org.eclipse.jgit.api.ResetCommand.ResetType.HARD
+
 class WorkspaceProvider implements Provider<File> {
-	
+
+	static val logger = LoggerFactory.getLogger(WorkspaceProvider)
+
 	@Inject extension GitConfiguration
 	@Inject extension GitProvider
-	
+
 	override get() {
 		return new File(localRepoFileRoot) => [
-			git.pull.call		
+			logger.info('fetching latest changes from remote repository')
+			git.fetch.configureTransport.call
+			val remoteTrackingBranch = new BranchConfig(git.repository.config, git.repository.branch).remoteTrackingBranch
+			git.reset => [
+				mode = HARD
+				ref = remoteTrackingBranch
+				call
+			]
 		]
-	}	
+	}
+
 }


### PR DESCRIPTION
A pull may fail if the history of the branch was rewritten. This simply discards whatever we have locally, and overwrites it with the remote branch.