### PR TITLE
add REST endpoint to retrieve test artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,4 +39,4 @@ config.local.yml
 xvfb.error.log
 
 ### Docker build ###
-testeditor
+/testeditor

--- a/src/main/java/org/testeditor/web/backend/testexecution/TestArtifactResource.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/TestArtifactResource.xtend
@@ -1,0 +1,64 @@
+package org.testeditor.web.backend.testexecution
+
+import io.dropwizard.jersey.errors.LoggingExceptionMapper
+import java.io.FileInputStream
+import java.io.FileNotFoundException
+import java.io.InputStream
+import javax.inject.Inject
+import javax.ws.rs.GET
+import javax.ws.rs.Path
+import javax.ws.rs.PathParam
+import javax.ws.rs.Produces
+import javax.ws.rs.core.Context
+import javax.ws.rs.core.HttpHeaders
+import javax.ws.rs.core.MediaType
+import javax.ws.rs.core.Response
+import javax.ws.rs.ext.Provider
+import org.testeditor.web.backend.testexecution.workspace.MaliciousPathException
+import org.testeditor.web.backend.testexecution.workspace.MissingFileException
+import org.testeditor.web.backend.testexecution.workspace.TestArtifactAccessException
+import org.testeditor.web.backend.testexecution.workspace.WorkspaceProvider
+
+import static javax.ws.rs.core.Response.Status.OK
+import static javax.ws.rs.core.Response.status
+
+import static extension java.nio.file.Files.probeContentType
+
+@Path("/documents/{resourcePath:.*}")
+@Produces(MediaType.TEXT_PLAIN)
+class TestArtifactResource {
+
+	@Inject WorkspaceProvider workspaceProvider
+
+	@GET
+	def Response loadLocal(@PathParam("resourcePath") String resourcePath, @Context HttpHeaders headers) {
+			return status(OK).entity(loadLocal(resourcePath)).type(getType(resourcePath)).build
+	}
+	
+	def InputStream loadLocal(String resourcePath) throws FileNotFoundException {
+		return new FileInputStream(workspaceProvider.getLocalWorkspaceFile(resourcePath))
+	}
+	
+	def String getType(String resourcePath) {
+		val file = workspaceProvider.getLocalWorkspaceFile(resourcePath)
+		return file.toPath.probeContentType
+	}
+
+}
+
+@Provider
+class TestArtifactAccessExceptionMapper extends LoggingExceptionMapper<TestArtifactAccessException> {
+
+	def dispatch Response toResponse(MaliciousPathException e) {
+		val logId = logException(e)
+		val message = String.format("You are not allowed to access this resource. Your attempt has been logged (ID %016x).", logId);
+		return Response.status(Response.Status.FORBIDDEN).entity(message).build
+	}
+
+	def dispatch Response toResponse(MissingFileException missingFileException) {
+		logException(missingFileException)
+
+		return Response.status(Response.Status.NOT_FOUND).entity(missingFileException.message).build
+	}
+
+}

--- a/src/main/java/org/testeditor/web/backend/testexecution/dropwizard/TestExecutionApplication.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/dropwizard/TestExecutionApplication.xtend
@@ -6,6 +6,7 @@ import java.util.List
 import javax.inject.Inject
 import javax.inject.Provider
 import javax.servlet.FilterRegistration.Dynamic
+import org.testeditor.web.backend.testexecution.TestArtifactResource
 import org.testeditor.web.backend.testexecution.TestExecutionExceptionMapper
 import org.testeditor.web.backend.testexecution.TestSuiteResource
 import org.testeditor.web.dropwizard.DropwizardApplication
@@ -30,6 +31,7 @@ class TestExecutionApplication extends DropwizardApplication<TestExecutionDropwi
 		environment.jersey => [
 			register(TestExecutionExceptionMapper)
 			register(TestSuiteResource)
+			register(TestArtifactResource)
 		]
 
 		environment.healthChecks.register('execution', executionHealthCheckProvider.get)

--- a/src/main/java/org/testeditor/web/backend/testexecution/workspace/WorkspaceProvider.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/workspace/WorkspaceProvider.xtend
@@ -4,9 +4,13 @@ import java.io.File
 import javax.inject.Inject
 import javax.inject.Provider
 import org.eclipse.jgit.lib.BranchConfig
+import org.eclipse.xtend.lib.annotations.Accessors
+import org.eclipse.xtend.lib.annotations.Data
+import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor
 import org.slf4j.LoggerFactory
 import org.testeditor.web.backend.testexecution.dropwizard.GitConfiguration
 import org.testeditor.web.backend.testexecution.git.GitProvider
+import org.testeditor.web.dropwizard.auth.User
 
 import static org.eclipse.jgit.api.ResetCommand.ResetType.HARD
 
@@ -16,6 +20,7 @@ class WorkspaceProvider implements Provider<File> {
 
 	@Inject extension GitConfiguration
 	@Inject extension GitProvider
+	@Inject Provider<User> userProvider
 
 	override get() {
 		return new File(localRepoFileRoot) => [
@@ -28,6 +33,58 @@ class WorkspaceProvider implements Provider<File> {
 				call
 			]
 		]
+	}
+
+	/**
+	 * Get a file in the workspace without updating first, e.g. for local files not under version control.
+	 */
+	def File getLocalWorkspaceFile(String resourcePath) {
+		val workspace = new File(localRepoFileRoot)
+		return new File(workspace, resourcePath) => [ file |
+			if (!workspace.isValidPath(file)) {
+				throw new MaliciousPathException(workspace.absolutePath, file.absolutePath, userProvider?.get?.name ?: '<UNKNOWN>')
+			} else if (!file.exists) {
+				throw new MissingFileException('''The file '«resourcePath»' does not exist.''')
+			}
+		]
+	}
+
+	private def boolean isValidPath(File workspace, File workspaceFile) {
+		val workspacePath = workspace.canonicalPath
+		val filePath = workspaceFile.canonicalPath
+		return filePath.startsWith(workspacePath)
+	}
+
+}
+
+@FinalFieldsConstructor
+class TestArtifactAccessException extends Exception {
+
+	@Accessors
+	val String message
+
+}
+
+@Data
+class MaliciousPathException extends TestArtifactAccessException {
+
+	String workspacePath
+	String resourcePath
+	String userName
+
+	new(String workspacePath, String resourcePath, String userName) {
+		super('''User='«userName»' tried to access resource='«resourcePath»' which is not within its workspace='«workspacePath»'.''')
+		this.workspacePath = workspacePath
+		this.resourcePath = resourcePath
+		this.userName = userName
+	}
+
+}
+
+class MissingFileException extends TestArtifactAccessException {
+
+	new(String message) {
+		super(message)
 	}
 
 }


### PR DESCRIPTION
... previously, the screenshots were retrieved via the persistence backend's normal document endpoint. With the introduction of a separate test execution backend, screenshots need to be retrieved from here. The new endpoint "salvages" code from the corresponding endpoints in the persistence backend, but stripped down to the essentials.
The REST interface has been left identical, so only minimal changes are necessary at the frontend.