### PR TITLE
update assertj (-> 3.12), mockito (-> 3.1)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,8 +65,8 @@ dependencies {
 
     testImplementation "junit:junit:4.12"
     testImplementation "io.dropwizard:dropwizard-testing:$versions.dropwizard"
-    testImplementation "org.assertj:assertj-core:3.8.0"
-    testImplementation "org.mockito:mockito-core:2.11.0"
+    testImplementation "org.assertj:assertj-core:3.12.0"
+    testImplementation "org.mockito:mockito-core:3.1.0"
     testImplementation "org.eclipse.xtext:org.eclipse.xtext.testing:$versions.xtext"
 	testImplementation "org.testeditor.web:org.testeditor.web.dropwizard.testing:$versions.testEditorDropwizard"
 	testImplementation 'org.eclipse.jgit:org.eclipse.jgit.junit:5.1.2.201810061102-r'


### PR DESCRIPTION
Older versions of both AssertJ and Mockito access `sun.misc.Unsafe` through (an older version of) ByteBuddy. The `Unsafe` class has been removed from Java 11.
The latest versions of these two test libraries have fixed this, so by updating, all the tests will now run in a Java 11 VM, as well.

See e.g.
* [Mockito issue](https://github.com/mockito/mockito/issues/1419)
* [AssertJ release notes](https://joel-costigliola.github.io/assertj/assertj-core-news.html#assertj-core-3.11.0)