### PR TITLE
Fix/command paths

### DIFF
--- a/src/main/java/org/testeditor/web/backend/testexecution/TestExecutorProvider.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/TestExecutorProvider.xtend
@@ -48,11 +48,11 @@ class TestExecutorProvider {
 	}
 
 	private def String getWhichSh() {
-		return commandPaths.computeIfAbsent('sh')[configuration.nicePath.getIfPresentOrElse[runShellCommand('which', 'sh')]]
+		return commandPaths.computeIfAbsent('sh')[configuration.shPath.getIfPresentOrElse[runShellCommand('which', 'sh')]]
 	}
 
 	private def String getWhichXvfbrun() {
-		return commandPaths.computeIfAbsent('xvfbrun')[configuration.nicePath.getIfPresentOrElse[runShellCommand('which', 'xvfb-run')]]
+		return commandPaths.computeIfAbsent('xvfbrun')[configuration.xvfbrunPath.getIfPresentOrElse[runShellCommand('which', 'xvfb-run')]]
 	}
 
 	private def <T> T getOrDefault(T value, (T)=>Boolean condition, ()=>T defaultValue) {

--- a/src/main/java/org/testeditor/web/backend/testexecution/TestExecutorProvider.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/TestExecutorProvider.xtend
@@ -213,20 +213,19 @@ class TestExecutorProvider {
 	}
 
 	private def String[] constructCommandLine(String testClass) {
-		if (System.getenv('TRAVIS').isNullOrEmpty) {
-			return #[whichNice, '-n', '10', whichXvfbrun, '-e', 'xvfb.error.log', '--server-args=-screen 0 1920x1080x16', whichSh, '-c',
-				testClass.gradleTestCommandLine]
-		} else {
-			return #[whichSh, '-c', testClass.gradleTestCommandLine]
-		}
+		return testClass.gradleTestCommandLine.withEnclosingCommands
 	}
 
 	private def String[] constructCommandLine(TestExecutionKey key, Iterable<String> testCases) {
+		return key.gradleTestCommandLine(testCases).withEnclosingCommands
+	}
+	
+	private def String[] withEnclosingCommands(String gradleTestCommandLine) {
 		if (System.getenv('TRAVIS').isNullOrEmpty) {
-			return #[whichNice, '-n', '10', whichXvfbrun, '-e', 'xvfb.error.log', '--server-args=-screen 0 1920x1080x16', whichSh, '-c',
-				key.gradleTestCommandLine(testCases)]
+			return #[whichNice, '-n', '10', whichXvfbrun, '-d', '-e', 'xvfb.error.log', '--server-args=-screen 0 1920x1080x16', whichSh, '-c',
+				gradleTestCommandLine]
 		} else {
-			return #[whichSh, '-c', key.gradleTestCommandLine(testCases)]
+			return #[whichSh, '-c', gradleTestCommandLine]
 		}
 	}
 

--- a/src/test/java/org/testeditor/web/backend/testexecution/TestSuiteExecutorIntegrationTest.xtend
+++ b/src/test/java/org/testeditor/web/backend/testexecution/TestSuiteExecutorIntegrationTest.xtend
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonFactory
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.JsonNodeType
 import java.io.File
+import java.nio.file.Paths
 import java.util.List
 import java.util.Map
 import java.util.concurrent.TimeUnit
@@ -13,12 +14,29 @@ import javax.ws.rs.core.GenericType
 import javax.ws.rs.core.MediaType
 import org.assertj.core.api.SoftAssertions
 import org.eclipse.jgit.junit.JGitTestUtil
+import org.junit.After
 import org.junit.Test
 
 import static javax.ws.rs.core.Response.Status.*
 import static org.assertj.core.api.Assertions.*
 
+import static extension java.nio.file.Files.exists
+import static extension java.nio.file.Files.lines
+
 class TestSuiteExecutorIntegrationTest extends AbstractIntegrationTest {
+	
+	@After
+	def void printXvfbLog() {
+		Paths.get(workspaceRoot.root.absolutePath, 'xvfb.error.log') => [
+			if (exists) {
+				lines.forEach[logLine | 
+					println('''xvfb.error.log: «logLine»''')
+				]
+			} else {
+				println('no "xvfb.error.log" file has been written.')
+			}
+		]
+	}
 
 	@Test
 	def void testThatCallTreeIsNotFoundIfNotExistent() {


### PR DESCRIPTION
This addresses two issues related to test execution w/ xvfb:
* the paths for `nice`, `xvfb-run` and `sh` are configurable, but there were two copy&paste mistakes when retrieving their values from the application's config.
* locally, several integration tests were failing, due to xvfb-run being unable to allocate a display number (see commit message of https://github.com/test-editor/test-editor-testexecution/commit/bb4a14cf7565e9af8986e75f5d6d27c77d890f79).