### PR TITLE
Feature/worker interfaces

### DIFF
--- a/src/main/java/org/testeditor/web/backend/testexecution/TestExecutionKey.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/TestExecutionKey.xtend
@@ -1,5 +1,7 @@
 package org.testeditor.web.backend.testexecution
 
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonProperty
 import java.io.File
 import java.io.FileNotFoundException
 import java.nio.file.FileSystems
@@ -35,7 +37,13 @@ class TestExecutionKey {
 		this(suiteId, suiteRunId, caseRunId, "")
 	}
 
-	new(String suiteId, String suiteRunId, String caseRunId, String callTreeId) {
+	@JsonCreator
+	new(
+		@JsonProperty('suiteId') String suiteId,
+		@JsonProperty('suiteRunId') String suiteRunId,
+		@JsonProperty('caseRunId') String caseRunId,
+		@JsonProperty('callTreeId') String callTreeId
+	) {
 		this.suiteId = suiteId
 		this.suiteRunId = suiteRunId
 		this.caseRunId = caseRunId

--- a/src/main/java/org/testeditor/web/backend/testexecution/TestSuiteResource.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/TestSuiteResource.xtend
@@ -2,17 +2,15 @@ package org.testeditor.web.backend.testexecution
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
-import java.io.File
 import java.io.FileNotFoundException
 import java.net.URI
 import java.net.URLEncoder
-import java.nio.file.Files
-import java.time.Instant
 import java.util.List
 import java.util.concurrent.Executor
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import javax.ws.rs.Consumes
+import javax.ws.rs.DELETE
 import javax.ws.rs.DefaultValue
 import javax.ws.rs.GET
 import javax.ws.rs.POST
@@ -27,15 +25,15 @@ import javax.ws.rs.core.Response
 import javax.ws.rs.core.Response.Status
 import javax.ws.rs.core.UriBuilder
 import org.slf4j.LoggerFactory
+import org.testeditor.web.backend.testexecution.distributed.manager.TestExecutionManager
+import org.testeditor.web.backend.testexecution.distributed.manager.TestJob
 import org.testeditor.web.backend.testexecution.loglines.LogFinder
 import org.testeditor.web.backend.testexecution.loglines.LogLevel
 import org.testeditor.web.backend.testexecution.screenshots.ScreenshotFinder
 
-import static java.nio.charset.StandardCharsets.UTF_8
-import static java.nio.file.StandardOpenOption.*
+import static javax.ws.rs.core.Response.Status.NOT_FOUND
 
 import static extension com.fasterxml.jackson.core.util.BufferRecyclers.quoteAsJsonText
-import javax.ws.rs.DELETE
 
 @Path("/test-suite")
 @Consumes(MediaType.APPLICATION_JSON, MediaType.TEXT_PLAIN)
@@ -46,11 +44,11 @@ class TestSuiteResource {
 
 	@Inject TestExecutorProvider executorProvider
 	@Inject TestStatusMapper statusMapper
-	@Inject extension TestLogWriter logWriter
 	@Inject Executor executor
 	@Inject TestExecutionCallTree testExecutionCallTree
 	@Inject ScreenshotFinder screenshotFinder
 	@Inject LogFinder logFinder
+	@Inject TestExecutionManager manager
 
 	@GET
 	@Path("{suiteId}/{suiteRunId}/{caseRunId : ([^?/]+)?}/{callTreeId : ([^?/]+)?}")
@@ -144,8 +142,7 @@ class TestSuiteResource {
 			}
 		}
 	}
-	
-	
+
 	@DELETE
 	@Path("{suiteId}/{suiteRunId}")
 	@Produces(MediaType.APPLICATION_JSON)
@@ -155,10 +152,10 @@ class TestSuiteResource {
 	) {
 		val executionKey = new TestExecutionKey(suiteId, suiteRunId)
 		return if (statusMapper.getStatus(executionKey) === TestStatus.RUNNING) {
-			statusMapper.terminateTestSuiteRun(executionKey)
+			manager.cancelJob(executionKey)
 			Response.ok.build
 		} else {
-			Response.status(Status.NOT_FOUND).build	
+			Response.status(NOT_FOUND).build			
 		}
 	}
 
@@ -167,16 +164,7 @@ class TestSuiteResource {
 	def Response launchNewSuiteWith(List<String> resourcePaths) {
 		val suiteKey = new TestExecutionKey("0") // default suite
 		val executionKey = statusMapper.deriveFreshRunId(suiteKey)
-		val builder = executorProvider.testExecutionBuilder(executionKey, resourcePaths, '') // commit id unknown
-		val logFile = builder.environment.get(TestExecutorProvider.LOGFILE_ENV_KEY)
-		val callTreeFileName = builder.environment.get(TestExecutorProvider.CALL_TREE_YAML_FILE)
-		logger.
-			info('''Starting test for resourcePaths='«resourcePaths.join(',')»' logging into logFile='«logFile»', callTreeFile='«callTreeFileName»'.''')
-		val callTreeFile = new File(callTreeFileName)
-		callTreeFile.writeCallTreeYamlPrefix(executorProvider.yamlFileHeader(executionKey, Instant.now, resourcePaths))
-		val testProcess = builder.start
-		statusMapper.addTestSuiteRun(executionKey, testProcess)[status|callTreeFile.writeCallTreeYamlSuffix(status)]
-		testProcess.logToStandardOutAndIntoFile(new File(logFile))
+		manager.addJob(new TestJob(executionKey, emptySet, resourcePaths))
 		val uri = new URI(UriBuilder.fromResource(TestSuiteResource).build.toString +
 			'''/«URLEncoder.encode(executionKey.suiteId, "UTF-8")»/«URLEncoder.encode(executionKey.suiteRunId,"UTF-8")»''')
 		return Response.created(uri).build
@@ -187,16 +175,6 @@ class TestSuiteResource {
 	@Produces(MediaType.APPLICATION_JSON)
 	def Iterable<TestSuiteStatusInfo> getStatusAll() {
 		return statusMapper.allTestSuites
-	}
-
-	private def File writeCallTreeYamlPrefix(File callTreeYamlFile, String fileHeader) {
-		callTreeYamlFile.parentFile.mkdirs
-		Files.write(callTreeYamlFile.toPath, fileHeader.getBytes(UTF_8), CREATE, TRUNCATE_EXISTING)
-		return callTreeYamlFile
-	}
-
-	private def void writeCallTreeYamlSuffix(File callTreeYamlFile, TestStatus testStatus) {
-		Files.write(callTreeYamlFile.toPath, #['''"status": "«testStatus»"'''], UTF_8, APPEND)
 	}
 
 	private def void waitForStatus(TestExecutionKey executionKey, AsyncResponse response) {

--- a/src/main/java/org/testeditor/web/backend/testexecution/distributed/manager/TestExecutionManager.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/distributed/manager/TestExecutionManager.xtend
@@ -1,0 +1,52 @@
+package org.testeditor.web.backend.testexecution.distributed.manager
+
+import java.io.File
+import java.time.Instant
+import javax.inject.Inject
+import org.slf4j.LoggerFactory
+import org.testeditor.web.backend.testexecution.TestExecutionKey
+import org.testeditor.web.backend.testexecution.TestExecutorProvider
+import org.testeditor.web.backend.testexecution.TestLogWriter
+import org.testeditor.web.backend.testexecution.TestStatusMapper
+import org.testeditor.web.backend.testexecution.util.CallTreeYamlUtil
+
+import static org.testeditor.web.backend.testexecution.TestExecutorProvider.CALL_TREE_YAML_FILE
+import static org.testeditor.web.backend.testexecution.TestExecutorProvider.LOGFILE_ENV_KEY
+import static org.testeditor.web.backend.testexecution.TestStatus.RUNNING
+
+interface TestExecutionManager {
+
+	def void cancelJob(TestExecutionKey key)
+
+	def void addJob(TestJob job)
+
+}
+
+class LocalSingleWorkerExecutionManager implements TestExecutionManager {
+	static val logger = LoggerFactory.getLogger(LocalSingleWorkerExecutionManager)
+
+	@Inject TestExecutorProvider executorProvider
+	@Inject TestStatusMapper statusMapper
+
+	@Inject extension TestLogWriter
+	@Inject extension CallTreeYamlUtil
+
+	override cancelJob(TestExecutionKey key) {
+		if (statusMapper.getStatus(key) === RUNNING) {
+			statusMapper.terminateTestSuiteRun(key)
+		}
+	}
+
+	override addJob(TestJob it) {
+		val builder = executorProvider.testExecutionBuilder(id, resourcePaths, '') // commit id unknown
+		val logFile = builder.environment.get(LOGFILE_ENV_KEY)
+		val callTreeFileName = builder.environment.get(CALL_TREE_YAML_FILE)
+		logger.info('''Starting test for resourcePaths='«resourcePaths.join(',')»' logging into logFile='«logFile»', callTreeFile='«callTreeFileName»'.''')
+		val callTreeFile = new File(callTreeFileName)
+		callTreeFile.writeCallTreeYamlPrefix(executorProvider.yamlFileHeader(id, Instant.now, resourcePaths))
+		val testProcess = builder.start
+		statusMapper.addTestSuiteRun(id, testProcess)[status|callTreeFile.writeCallTreeYamlSuffix(status)]
+		testProcess.logToStandardOutAndIntoFile(new File(logFile))
+	}
+
+}

--- a/src/main/java/org/testeditor/web/backend/testexecution/distributed/manager/TestJob.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/distributed/manager/TestJob.xtend
@@ -1,0 +1,59 @@
+package org.testeditor.web.backend.testexecution.distributed.manager
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonProperty
+import java.util.ArrayList
+import java.util.HashSet
+import java.util.List
+import java.util.Set
+import org.eclipse.xtend.lib.annotations.Accessors
+import org.eclipse.xtend.lib.annotations.Data
+import org.eclipse.xtend.lib.annotations.EqualsHashCode
+import org.testeditor.web.backend.testexecution.TestExecutionKey
+
+interface TestJobInfo {
+	def TestExecutionKey getId()
+	def Set<String> getRequiredCapabilities()
+	def List<String> getResourcePaths()
+	def JobState getState()
+	def TestJobInfo setState(JobState state)
+	
+	enum JobState {
+
+		PENDING,
+		ASSIGNING,
+		ASSIGNED,
+		COMPLETED
+
+	}
+}
+
+@EqualsHashCode
+@Data
+class TestJob implements TestJobInfo {
+
+	public static val TestJob NONE = new TestJob(new TestExecutionKey(''), emptySet, emptyList)
+
+	val TestExecutionKey id
+	val Set<String> requiredCapabilities
+	val List<String> resourcePaths
+	@Accessors(PUBLIC_GETTER)
+	transient val JobState state
+
+	@JsonCreator
+	new(@JsonProperty('id') TestExecutionKey id, @JsonProperty('requiredCapabilities') Set<String> capabilities, @JsonProperty('resourcePaths') List<String> resourcePaths) {
+		this(id, new HashSet(capabilities), new ArrayList(resourcePaths), JobState.PENDING)
+	}
+	
+	private new(TestExecutionKey id, Set<String> capabilities, List<String> resourcePaths, JobState state) {
+		this.id = id
+		this.requiredCapabilities = new HashSet(capabilities)
+		this.resourcePaths = new ArrayList(resourcePaths)
+		this.state = state
+	}
+	
+	override TestJobInfo setState(JobState state) {
+		return new TestJob(this.id, this.requiredCapabilities, this.resourcePaths, state)
+	}
+
+}

--- a/src/main/java/org/testeditor/web/backend/testexecution/dropwizard/TestExecutionModule.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/dropwizard/TestExecutionModule.xtend
@@ -5,6 +5,8 @@ import com.google.inject.Provides
 import java.io.File
 import java.util.concurrent.Executor
 import java.util.concurrent.ForkJoinPool
+import org.testeditor.web.backend.testexecution.distributed.manager.LocalSingleWorkerExecutionManager
+import org.testeditor.web.backend.testexecution.distributed.manager.TestExecutionManager
 import org.testeditor.web.backend.testexecution.loglines.Log4JDefaultFilter
 import org.testeditor.web.backend.testexecution.loglines.LogFilter
 import org.testeditor.web.backend.testexecution.loglines.LogFinder
@@ -28,6 +30,7 @@ class TestExecutionModule extends AbstractModule {
 			bind(File).annotatedWith(named("workspace")).toProvider(WorkspaceProvider)
 			bind(TestExecutionConfiguration).to(TestExecutionDropwizardConfiguration)
 			bind(GitConfiguration).to(TestExecutionDropwizardConfiguration)
+			bind(TestExecutionManager).to(LocalSingleWorkerExecutionManager)
 		]
 	}
 

--- a/src/main/java/org/testeditor/web/backend/testexecution/util/CallTreeYamlUtil.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/util/CallTreeYamlUtil.xtend
@@ -1,0 +1,24 @@
+package org.testeditor.web.backend.testexecution.util
+
+import java.io.File
+import java.nio.file.Files
+import org.testeditor.web.backend.testexecution.TestStatus
+
+import static java.nio.charset.StandardCharsets.UTF_8
+import static java.nio.file.StandardOpenOption.APPEND
+import static java.nio.file.StandardOpenOption.CREATE
+import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING
+import javax.inject.Singleton
+
+@Singleton
+class CallTreeYamlUtil {
+	def File writeCallTreeYamlPrefix(File callTreeYamlFile, String fileHeader) {
+		callTreeYamlFile.parentFile.mkdirs
+		Files.write(callTreeYamlFile.toPath, fileHeader.getBytes(UTF_8), CREATE, TRUNCATE_EXISTING)
+		return callTreeYamlFile
+	}
+
+	def void writeCallTreeYamlSuffix(File callTreeYamlFile, TestStatus testStatus) {
+		Files.write(callTreeYamlFile.toPath, #['''"status": "«testStatus»"'''], UTF_8, APPEND)
+	}
+}

--- a/src/test/java/org/testeditor/web/backend/testexecution/distributed/manager/TestJobTest.xtend
+++ b/src/test/java/org/testeditor/web/backend/testexecution/distributed/manager/TestJobTest.xtend
@@ -1,0 +1,41 @@
+package org.testeditor.web.backend.testexecution.distributed.manager
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.dropwizard.jackson.Jackson
+import org.testeditor.web.backend.testexecution.TestExecutionKey
+
+import static io.dropwizard.testing.FixtureHelpers.*
+import static org.assertj.core.api.Assertions.assertThat
+
+class TestJobTest {
+
+	static val ObjectMapper mapper = Jackson.newObjectMapper();
+
+	@org.junit.Test
+	def void testJobSerializesToJSON() throws Exception {
+		// given
+		val testJob = new TestJob(new TestExecutionKey('suiteId', 'suiteRunId', 'testCaseId', 'callTreeId'), #{'firefox', 'chrome'},
+			#['path/to/test.tcl', 'another/differentTest.tcl'])
+		val expected = mapper.writeValueAsString(mapper.readValue(fixture("json/testJob.json"), TestJob))
+
+		// when
+		val actual = mapper.writeValueAsString(testJob)
+
+		// then
+		assertThat(actual).isEqualTo(expected)
+	}
+
+	@org.junit.Test
+	def void testJobDeserializesFromJSON() throws Exception {
+		// given
+		val testJob = new TestJob(new TestExecutionKey('suiteId', 'suiteRunId', 'testCaseId', 'callTreeId'), #{'firefox', 'chrome'},
+			#['path/to/test.tcl', 'another/differentTest.tcl'])
+
+		// when
+		val actual = mapper.readValue(fixture("json/testJob.json"), TestJob)
+
+		// then
+		assertThat(actual).isEqualTo(testJob)
+	}
+
+}

--- a/src/test/resources/json/testJob.json
+++ b/src/test/resources/json/testJob.json
@@ -1,0 +1,1 @@
+{"id":{"suiteId":"suiteId","suiteRunId":"suiteRunId","caseRunId":"testCaseId","callTreeId":"callTreeId"},"requiredCapabilities":["chrome","firefox"],"resourcePaths":["path/to/test.tcl","another/differentTest.tcl"]}


### PR DESCRIPTION
Note: this PR intentionally targets `feature/worker-revised`, instead of `master`, the idea being to first build up a first, basic and stable implementation w/ distributed test execution workers, PR by PR. This isn't set in stone, though, so if you want to make the case to merge this (and subsequent PRs) directly into master, go ahead! 🙂 

---

picking some basic abstractions from the [worker poc](https://github.com/test-editor/test-editor-testexecution/tree/feature/worker-poc):

* `TestExecutionManager` is intended to be responsible for job management (keeping track of a job queue, workers, assigning job to workers, etc.). For this first increment, only a minimal interface was extracted. There is no abstraction for workers, yet, at all. A default implementation simply reproduces the previous behavior.
* `TestJob` is a JSON-serializable abstraction for jobs to be sent to workers. Jobs are identified by their `TestExecutionKey`, a pre-existing class used to identify test runs, now made JSON-serializable, too.