### PR TITLE
Feature/worker abstractions

### DIFF
--- a/src/main/java/org/testeditor/web/backend/testexecution/RunningTest.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/RunningTest.xtend
@@ -1,0 +1,11 @@
+package org.testeditor.web.backend.testexecution
+
+interface RunningTest {
+
+	def TestStatus checkStatus()
+
+	def TestStatus waitForStatus()
+
+	def void kill()
+
+}

--- a/src/main/java/org/testeditor/web/backend/testexecution/TestProcess.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/TestProcess.xtend
@@ -23,7 +23,7 @@ import static org.testeditor.web.backend.testexecution.TestStatus.*
  *    it terminated, the only value that can be written as status is its
  *    exit value, which is fixed at that point. 
  */
-class TestProcess {
+class TestProcess implements RunningTest {
 
 	static val logger = LoggerFactory.getLogger(TestProcess)
 
@@ -61,7 +61,7 @@ class TestProcess {
 	 * subprocesses have all terminated, and if so, updates the status
 	 * accordingly, before returning it.
 	 */
-	def TestStatus checkStatus() {
+	override TestStatus checkStatus() {
 		updateStatusIfAllProcessesTerminated
 		return status
 	}
@@ -71,7 +71,7 @@ class TestProcess {
 	 * longer than {@link #WAIT_TIMEOUT_SECONDS}. Returns {@link #checkStatus()}
 	 * as soon as the test process terminates, or after the timeout.
 	 */
-	def TestStatus waitForStatus() {
+	override TestStatus waitForStatus() {
 		if (process !== null && testIsAlive) {
 			waitForAll(WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
 		}
@@ -88,7 +88,7 @@ class TestProcess {
 	 * no descendants, even though some sub-processes that were sent into the
 	 * background are still running.
 	 */
-	def void kill() {
+	override void kill() {
 		val processRef = this.process
 		if (processRef !== null) {
 			val descendants = synchronized (descendantsBeforeKill) {

--- a/src/main/java/org/testeditor/web/backend/testexecution/TestSuiteResource.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/TestSuiteResource.xtend
@@ -25,8 +25,8 @@ import javax.ws.rs.core.Response
 import javax.ws.rs.core.Response.Status
 import javax.ws.rs.core.UriBuilder
 import org.slf4j.LoggerFactory
+import org.testeditor.web.backend.testexecution.distributed.common.TestJob
 import org.testeditor.web.backend.testexecution.distributed.manager.TestExecutionManager
-import org.testeditor.web.backend.testexecution.distributed.manager.TestJob
 import org.testeditor.web.backend.testexecution.loglines.LogFinder
 import org.testeditor.web.backend.testexecution.loglines.LogLevel
 import org.testeditor.web.backend.testexecution.screenshots.ScreenshotFinder

--- a/src/main/java/org/testeditor/web/backend/testexecution/distributed/common/TestJob.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/distributed/common/TestJob.xtend
@@ -1,4 +1,4 @@
-package org.testeditor.web.backend.testexecution.distributed.manager
+package org.testeditor.web.backend.testexecution.distributed.common
 
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonProperty

--- a/src/main/java/org/testeditor/web/backend/testexecution/distributed/common/Worker.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/distributed/common/Worker.xtend
@@ -1,0 +1,20 @@
+package org.testeditor.web.backend.testexecution.distributed.common
+
+import java.net.URI
+import java.util.Set
+import java.util.concurrent.CompletionStage
+import org.testeditor.web.backend.testexecution.RunningTest
+
+interface WorkerInfo {
+
+	def URI getUri()
+
+	def Set<String> getProvidedCapabilities()
+
+}
+
+interface Worker extends RunningTest, WorkerInfo {
+
+	def CompletionStage<Boolean> startJob(TestJobInfo job)
+
+}

--- a/src/main/java/org/testeditor/web/backend/testexecution/distributed/manager/LocalSingleWorkerManager.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/distributed/manager/LocalSingleWorkerManager.xtend
@@ -1,0 +1,28 @@
+package org.testeditor.web.backend.testexecution.distributed.manager
+
+import javax.inject.Inject
+import org.testeditor.web.backend.testexecution.distributed.common.TestJob
+import org.testeditor.web.backend.testexecution.distributed.common.Worker
+import org.testeditor.web.backend.testexecution.distributed.common.WorkerInfo
+
+class LocalSingleWorkerManager implements WorkerProvider {
+
+	@Inject Worker worker
+
+	override getWorkers() {
+		return #[worker]
+	}
+
+	override assign(WorkerInfo worker, TestJob job) {
+		if (worker === this.worker) {
+			this.worker.startJob(job).toCompletableFuture.get
+		}
+	}
+
+	override cancel(WorkerInfo worker) {
+		if (worker === this.worker) {
+			this.worker.kill
+		}
+	}
+
+}

--- a/src/main/java/org/testeditor/web/backend/testexecution/distributed/manager/TestExecutionManager.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/distributed/manager/TestExecutionManager.xtend
@@ -8,6 +8,7 @@ import org.testeditor.web.backend.testexecution.TestExecutionKey
 import org.testeditor.web.backend.testexecution.TestExecutorProvider
 import org.testeditor.web.backend.testexecution.TestLogWriter
 import org.testeditor.web.backend.testexecution.TestStatusMapper
+import org.testeditor.web.backend.testexecution.distributed.common.TestJob
 import org.testeditor.web.backend.testexecution.util.CallTreeYamlUtil
 
 import static org.testeditor.web.backend.testexecution.TestExecutorProvider.CALL_TREE_YAML_FILE

--- a/src/main/java/org/testeditor/web/backend/testexecution/distributed/manager/TestExecutionManager.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/distributed/manager/TestExecutionManager.xtend
@@ -1,19 +1,10 @@
 package org.testeditor.web.backend.testexecution.distributed.manager
 
-import java.io.File
-import java.time.Instant
+import java.util.Optional
 import javax.inject.Inject
-import org.slf4j.LoggerFactory
+import javax.inject.Singleton
 import org.testeditor.web.backend.testexecution.TestExecutionKey
-import org.testeditor.web.backend.testexecution.TestExecutorProvider
-import org.testeditor.web.backend.testexecution.TestLogWriter
-import org.testeditor.web.backend.testexecution.TestStatusMapper
 import org.testeditor.web.backend.testexecution.distributed.common.TestJob
-import org.testeditor.web.backend.testexecution.util.CallTreeYamlUtil
-
-import static org.testeditor.web.backend.testexecution.TestExecutorProvider.CALL_TREE_YAML_FILE
-import static org.testeditor.web.backend.testexecution.TestExecutorProvider.LOGFILE_ENV_KEY
-import static org.testeditor.web.backend.testexecution.TestStatus.RUNNING
 
 interface TestExecutionManager {
 
@@ -23,31 +14,22 @@ interface TestExecutionManager {
 
 }
 
+@Singleton
 class LocalSingleWorkerExecutionManager implements TestExecutionManager {
-	static val logger = LoggerFactory.getLogger(LocalSingleWorkerExecutionManager)
+	@Inject extension WorkerProvider
 
-	@Inject TestExecutorProvider executorProvider
-	@Inject TestStatusMapper statusMapper
-
-	@Inject extension TestLogWriter
-	@Inject extension CallTreeYamlUtil
+	var Optional<TestExecutionKey> currentJob = Optional.empty
 
 	override cancelJob(TestExecutionKey key) {
-		if (statusMapper.getStatus(key) === RUNNING) {
-			statusMapper.terminateTestSuiteRun(key)
-		}
+		currentJob.filter[it == key].ifPresent[
+			workers.head.cancel
+			currentJob = Optional.empty
+		]
 	}
 
 	override addJob(TestJob it) {
-		val builder = executorProvider.testExecutionBuilder(id, resourcePaths, '') // commit id unknown
-		val logFile = builder.environment.get(LOGFILE_ENV_KEY)
-		val callTreeFileName = builder.environment.get(CALL_TREE_YAML_FILE)
-		logger.info('''Starting test for resourcePaths='«resourcePaths.join(',')»' logging into logFile='«logFile»', callTreeFile='«callTreeFileName»'.''')
-		val callTreeFile = new File(callTreeFileName)
-		callTreeFile.writeCallTreeYamlPrefix(executorProvider.yamlFileHeader(id, Instant.now, resourcePaths))
-		val testProcess = builder.start
-		statusMapper.addTestSuiteRun(id, testProcess)[status|callTreeFile.writeCallTreeYamlSuffix(status)]
-		testProcess.logToStandardOutAndIntoFile(new File(logFile))
+		workers.head.assign(it)
+		currentJob = Optional.of(id)
 	}
 
 }

--- a/src/main/java/org/testeditor/web/backend/testexecution/distributed/manager/WorkerProvider.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/distributed/manager/WorkerProvider.xtend
@@ -1,0 +1,13 @@
+package org.testeditor.web.backend.testexecution.distributed.manager
+
+import org.testeditor.web.backend.testexecution.distributed.common.TestJob
+import org.testeditor.web.backend.testexecution.distributed.common.WorkerInfo
+
+interface WorkerProvider {
+
+	def Iterable<WorkerInfo> getWorkers()
+
+	def void assign(WorkerInfo worker, TestJob job)
+
+	def void cancel(WorkerInfo worker)
+}

--- a/src/main/java/org/testeditor/web/backend/testexecution/distributed/worker/LocalSingleWorker.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/distributed/worker/LocalSingleWorker.xtend
@@ -1,0 +1,73 @@
+package org.testeditor.web.backend.testexecution.distributed.worker
+
+import java.io.File
+import java.time.Instant
+import java.util.Optional
+import java.util.concurrent.CompletableFuture
+import javax.inject.Inject
+import javax.inject.Provider
+import org.slf4j.LoggerFactory
+import org.testeditor.web.backend.testexecution.TestExecutorProvider
+import org.testeditor.web.backend.testexecution.TestLogWriter
+import org.testeditor.web.backend.testexecution.TestStatus
+import org.testeditor.web.backend.testexecution.TestStatusMapper
+import org.testeditor.web.backend.testexecution.distributed.common.TestJobInfo
+import org.testeditor.web.backend.testexecution.distributed.common.Worker
+import org.testeditor.web.backend.testexecution.util.CallTreeYamlUtil
+
+import static org.testeditor.web.backend.testexecution.TestExecutorProvider.CALL_TREE_YAML_FILE
+import static org.testeditor.web.backend.testexecution.TestExecutorProvider.LOGFILE_ENV_KEY
+
+class LocalSingleWorker implements Worker {
+	static val logger = LoggerFactory.getLogger(LocalSingleWorker)
+
+	@Inject extension TestStatusMapper statusMapper
+	@Inject Provider<TestExecutorProvider> _executorProvider // eager initialization causes injection trouble due to Dropwizard env not being set
+	@Inject extension TestLogWriter
+	@Inject extension CallTreeYamlUtil
+	
+	var Optional<TestJobInfo> currentJob = Optional.empty
+	
+	private def TestExecutorProvider executorProvider() { _executorProvider.get }
+
+	override startJob(TestJobInfo it) {
+		currentJob = Optional.of(it)
+		val builder = executorProvider.testExecutionBuilder(id, resourcePaths, '') // commit id unknown
+		val logFile = builder.environment.get(LOGFILE_ENV_KEY)
+		val callTreeFileName = builder.environment.get(CALL_TREE_YAML_FILE)
+		logger.
+			info('''Starting test for resourcePaths='«resourcePaths.join(',')»' logging into logFile='«logFile»', callTreeFile='«callTreeFileName»'.''')
+		val callTreeFile = new File(callTreeFileName)
+		callTreeFile.writeCallTreeYamlPrefix(executorProvider.yamlFileHeader(id, Instant.now, resourcePaths))
+		val testProcess = builder.start
+		statusMapper.addTestSuiteRun(id, testProcess)[status|callTreeFile.writeCallTreeYamlSuffix(status)]
+		testProcess.logToStandardOutAndIntoFile(new File(logFile))
+		
+		return CompletableFuture.completedFuture(true)
+	}
+
+	override checkStatus() {
+		currentJob.map[id.getStatus].orElse(TestStatus.IDLE)
+	}
+
+	override waitForStatus() {
+		currentJob.map[id.waitForStatus].orElse(TestStatus.IDLE)
+	}
+
+	override kill() {
+		currentJob.ifPresent[
+			if (id.getStatus === TestStatus.RUNNING) {
+				id.terminateTestSuiteRun
+			}
+		]
+	}
+
+	override getUri() {
+		throw new UnsupportedOperationException("TODO: auto-generated method stub")
+	}
+
+	override getProvidedCapabilities() {
+		throw new UnsupportedOperationException("TODO: auto-generated method stub")
+	}
+
+}

--- a/src/main/java/org/testeditor/web/backend/testexecution/dropwizard/LocalSingleWorkerModule.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/dropwizard/LocalSingleWorkerModule.xtend
@@ -1,0 +1,19 @@
+package org.testeditor.web.backend.testexecution.dropwizard
+
+import com.google.inject.AbstractModule
+import org.testeditor.web.backend.testexecution.distributed.common.Worker
+import org.testeditor.web.backend.testexecution.distributed.manager.LocalSingleWorkerExecutionManager
+import org.testeditor.web.backend.testexecution.distributed.manager.LocalSingleWorkerManager
+import org.testeditor.web.backend.testexecution.distributed.manager.TestExecutionManager
+import org.testeditor.web.backend.testexecution.distributed.manager.WorkerProvider
+import org.testeditor.web.backend.testexecution.distributed.worker.LocalSingleWorker
+
+class LocalSingleWorkerModule extends AbstractModule {
+	override protected configure() {
+		binder => [
+			bind(TestExecutionManager).to(LocalSingleWorkerExecutionManager)
+			bind(WorkerProvider).to(LocalSingleWorkerManager)
+			bind(Worker).to(LocalSingleWorker)
+		]
+	}
+}

--- a/src/main/java/org/testeditor/web/backend/testexecution/dropwizard/TestExecutionApplication.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/dropwizard/TestExecutionApplication.xtend
@@ -23,7 +23,7 @@ class TestExecutionApplication extends DropwizardApplication<TestExecutionDropwi
 
 	override protected collectModules(List<Module> modules) {
 		super.collectModules(modules)
-		modules += new TestExecutionModule
+		modules += #[ new TestExecutionModule, new LocalSingleWorkerModule ]
 	}
 
 	override run(TestExecutionDropwizardConfiguration configuration, Environment environment) throws Exception {

--- a/src/main/java/org/testeditor/web/backend/testexecution/dropwizard/TestExecutionModule.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/dropwizard/TestExecutionModule.xtend
@@ -30,7 +30,6 @@ class TestExecutionModule extends AbstractModule {
 			bind(File).annotatedWith(named("workspace")).toProvider(WorkspaceProvider)
 			bind(TestExecutionConfiguration).to(TestExecutionDropwizardConfiguration)
 			bind(GitConfiguration).to(TestExecutionDropwizardConfiguration)
-			bind(TestExecutionManager).to(LocalSingleWorkerExecutionManager)
 		]
 	}
 

--- a/src/test/java/org/testeditor/web/backend/testexecution/distributed/manager/TestJobTest.xtend
+++ b/src/test/java/org/testeditor/web/backend/testexecution/distributed/manager/TestJobTest.xtend
@@ -2,7 +2,9 @@ package org.testeditor.web.backend.testexecution.distributed.manager
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.dropwizard.jackson.Jackson
+import org.junit.Test
 import org.testeditor.web.backend.testexecution.TestExecutionKey
+import org.testeditor.web.backend.testexecution.distributed.common.TestJob
 
 import static io.dropwizard.testing.FixtureHelpers.*
 import static org.assertj.core.api.Assertions.assertThat
@@ -11,7 +13,7 @@ class TestJobTest {
 
 	static val ObjectMapper mapper = Jackson.newObjectMapper();
 
-	@org.junit.Test
+	@Test
 	def void testJobSerializesToJSON() throws Exception {
 		// given
 		val testJob = new TestJob(new TestExecutionKey('suiteId', 'suiteRunId', 'testCaseId', 'callTreeId'), #{'firefox', 'chrome'},
@@ -25,7 +27,7 @@ class TestJobTest {
 		assertThat(actual).isEqualTo(expected)
 	}
 
-	@org.junit.Test
+	@Test
 	def void testJobDeserializesFromJSON() throws Exception {
 		// given
 		val testJob = new TestJob(new TestExecutionKey('suiteId', 'suiteRunId', 'testCaseId', 'callTreeId'), #{'firefox', 'chrome'},


### PR DESCRIPTION
Draft, should target [feature/workers-revised](https://github.com/test-editor/test-editor-testexecution/tree/feature/workers-revised), once #15 has been merged.

This introduces the concept of a `Worker`, and moves the logic to start and cancel test execution, that was originally residing directly in `TestSuiteResource`, and then in the `TestExecutionManager` (`LocalSingleWorkerExecutionManager`), into `LocalSingleWorker`.

Some code was picked from [feature/worker-poc](https://github.com/test-editor/test-editor-testexecution/tree/feature/worker-poc), but most was quite heavily stripped down, or refactored. Most notably, the `TestExecutionManager` in the poc ended up managing both job queues and workers, with a nested dispatcher class assigning jobs to workers. In the spirit of the single responsibility principle, this has now been split, yielding a separate worker manager (`LocalSingleWorkerManager`). 

These are still just preparations for proper worker support, introducing multiple layers of indirection, which for now mostly only delegate to the next layer. The `LocalSingleWorkerModule` is a single point for configuring worker support to behave exactly like without workers at all, with the intention of later having to only swap out this Guice module against one that configures proper worker support.