### PR TITLE
Feature/decouple webapi from testexecution

### DIFF
--- a/src/main/java/org/testeditor/web/backend/testexecution/TestExecutionCallTree.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/TestExecutionCallTree.xtend
@@ -1,41 +1,21 @@
 package org.testeditor.web.backend.testexecution
 
-import java.io.File
 import java.util.ArrayList
 import java.util.List
 import java.util.Map
 import javax.inject.Inject
 import org.testeditor.web.backend.testexecution.common.TestExecutionKey
 import org.testeditor.web.backend.testexecution.util.serialization.JsonWriter
-import org.testeditor.web.backend.testexecution.util.serialization.YamlReader
 
 class TestExecutionCallTree {
 
-	@Inject extension YamlReader
 	@Inject extension JsonWriter
 
 	static val childrenKey = 'children'
 	static val idKey = 'id'
 
-	var TestExecutionKey executionKey
-	var Map<String, Object> yamlObject
-
-	def void readFile(TestExecutionKey executionKey, File yaml) {
-		yamlObject = yaml.readYaml
-		this.executionKey = executionKey
-	}
-
-	def void readString(TestExecutionKey executionKey, String yaml) {
-		if (yaml.nullOrEmpty) {
-			throw new IllegalArgumentException('Yaml string must not be null nor empty')
-		} else {
-			yamlObject = yaml.readYaml
-			this.executionKey = executionKey
-		}
-	}
-
-	def String getCompleteTestCallTreeJson(TestExecutionKey executionKey) {
-		val test = executionKey.testNode
+	def String getCompleteTestCallTreeJson(TestExecutionKey executionKey, ()=>Map<String,Object> yamlObjectProvider) {
+		val test = executionKey.testNode(yamlObjectProvider)
 		if (test !== null) {
 			return test.writeJson
 		} else {
@@ -43,8 +23,8 @@ class TestExecutionCallTree {
 		}
 	}
 
-	def String getNodeJson(TestExecutionKey executionKey) {
-		val test = executionKey.testNode
+	def String getNodeJson(TestExecutionKey executionKey, ()=>Map<String,Object> yamlObjectProvider) {
+		val test = executionKey.testNode(yamlObjectProvider)
 		val node = test.typedMapGetArray(childrenKey)?.findNode(executionKey.callTreeId)
 		if (node !== null) {
 			return node.writeToJsonHidingChildren
@@ -53,34 +33,32 @@ class TestExecutionCallTree {
 		}
 	}
 
-	def Iterable<TestExecutionKey> getDescendantsKeys(TestExecutionKey key) {
-		val node = key.testNode.typedMapGetArray(childrenKey)?.findNode(key.callTreeId)
+	def Iterable<TestExecutionKey> getDescendantsKeys(TestExecutionKey key, ()=>Map<String,Object> yamlObjectProvider) {
+		val node = key.testNode(yamlObjectProvider).typedMapGetArray(childrenKey)?.findNode(key.callTreeId)
 		return if (node !== null && !node.empty) {
-			node.descendantsKeys
+			node.descendantsKeys(key)
 		} else {
 			#[]
 		}
 	}
 
-	private def Iterable<TestExecutionKey> getDescendantsKeys(Map<String, Object> node) {
+	private def Iterable<TestExecutionKey> descendantsKeys(Map<String, Object> node, TestExecutionKey executionKey) {
 		val keys = newLinkedList()
 		if (node.get(childrenKey) !== null) {
 			node.<Map<String, Object>>typedMapGetArray(childrenKey).forEach [
 				keys += executionKey.deriveWithCallTreeId(get(idKey) as String)
-				keys += descendantsKeys
+				keys += descendantsKeys(executionKey)
 			]
 		}
 		return keys
 	}
 
-	private def Map<String, Object> getTestNode(TestExecutionKey executionKey) {
-		if (!(this.executionKey.suiteId.equals(executionKey.suiteId) && this.executionKey.suiteRunId.equals(executionKey.suiteRunId))) {
-			throw new IllegalArgumentException('''passed executionKey = '«executionKey»' does match test run execution key = '«this.executionKey»' ''')
-		} else if (executionKey.caseRunId.nullOrEmpty) {
+	private def Map<String, Object> testNode(TestExecutionKey executionKey, ()=>Map<String,Object> yamlObjectProvider) {
+		if (executionKey.caseRunId.nullOrEmpty) {
 			throw new IllegalArgumentException('''passed executionKey = '«executionKey»' must provide a caseRunId.''')
 		}
 
-		val testRuns = yamlObject.typedMapGetArray("testRuns").filter(Map)
+		val testRuns = yamlObjectProvider.apply.typedMapGetArray("testRuns").filter(Map)
 		val test = testRuns.findFirst [ test |
 			executionKey.caseRunId.equals(test.get("testRunId"))
 		]

--- a/src/main/java/org/testeditor/web/backend/testexecution/TestExecutionCallTree.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/TestExecutionCallTree.xtend
@@ -15,7 +15,7 @@ class TestExecutionCallTree {
 	static val idKey = 'id'
 
 	def String getCompleteTestCallTreeJson(TestExecutionKey executionKey, ()=>Map<String,Object> yamlObjectProvider) {
-		val test = executionKey.testNode(yamlObjectProvider)
+		val test = yamlObjectProvider.apply
 		if (test !== null) {
 			return test.writeJson
 		} else {

--- a/src/main/java/org/testeditor/web/backend/testexecution/TestExecutorProvider.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/TestExecutorProvider.xtend
@@ -165,21 +165,6 @@ class TestExecutorProvider {
 		return processBuilder
 	}
 
-	def Iterable<File> getTestFiles(String testCase) {
-		val testClass = testCase.testClass
-		val testPath = workspaceProvider.get.toPath.resolve(LOG_FOLDER)
-		val unfilteredtestFiles = testPath.toFile.listFiles
-		val testFiles = unfilteredtestFiles.filter[name.startsWith('''testrun-«testClass»-''')]
-		return testFiles
-	}
-
-	def Iterable<File> getTestFiles(TestExecutionKey executionKey) {
-		val testPath = workspaceProvider.get.toPath.resolve(LOG_FOLDER)
-		val unfilteredtestFiles = testPath.toFile.listFiles
-		val testFiles = unfilteredtestFiles.filter[name.startsWith('''testrun.«executionKey.toString».''')]
-		return testFiles
-	}
-
 	def String yamlFileHeader(TestExecutionKey executionKey, Instant instant, Iterable<String> resourcePaths) {
 		return '''
 			"started": "«StringEscapeUtils.escapeJava(instant.toString)»"

--- a/src/main/java/org/testeditor/web/backend/testexecution/TestExecutorProvider.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/TestExecutorProvider.xtend
@@ -4,14 +4,12 @@ import java.io.File
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.StandardOpenOption
-import java.time.Instant
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.util.HashMap
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Provider
-import org.apache.commons.text.StringEscapeUtils
 import org.slf4j.LoggerFactory
 import org.testeditor.web.backend.testexecution.common.TestExecutionConfiguration
 import org.testeditor.web.backend.testexecution.common.TestExecutionKey
@@ -163,16 +161,6 @@ class TestExecutorProvider {
 		]
 
 		return processBuilder
-	}
-
-	def String yamlFileHeader(TestExecutionKey executionKey, Instant instant, Iterable<String> resourcePaths) {
-		return '''
-			"started": "«StringEscapeUtils.escapeJava(instant.toString)»"
-			"testSuiteId": "«StringEscapeUtils.escapeJava(executionKey.suiteId)»"
-			"testSuiteRunId": "«StringEscapeUtils.escapeJava(executionKey.suiteRunId)»"
-			"resourcePaths": [ «resourcePaths.map['"'+StringEscapeUtils.escapeJava(it)+'"'].join(", ")» ]
-			"testRuns":
-		'''
 	}
 
 	private def String getTestClass(String testCase) {

--- a/src/main/java/org/testeditor/web/backend/testexecution/common/TestExecutionConfiguration.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/common/TestExecutionConfiguration.xtend
@@ -8,6 +8,21 @@ interface TestExecutionConfiguration {
 	def int getLongPollingTimeoutSeconds()
 	
 	/**
+	 * Maximum number of already executed test jobs to be kept in memory.
+	 * 
+	 * This only keeps basic test execution information, like which tests belong to the job, and what the execution status was, in memory.
+	 * On a cache miss, the information will be restored from the test execution's call tree yaml file.
+	 */
+	def int getTestJobCacheSize()
+	/**
+	 * Maximum number of complete call trees of already executed test jobs to be kept in memory.
+	 * 
+	 * This comprises the full details contained in test execution call trees. 
+	 * It does not include log data or screenshots.
+	 */
+	def int getTestJobCallTreeCacheSize()
+	
+	/**
      * Whether to skip over log entries produced by subordinate test steps.
      * 
      * When requesting the log lines for a particular test step via the

--- a/src/main/java/org/testeditor/web/backend/testexecution/common/TestExecutionKey.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/common/TestExecutionKey.xtend
@@ -17,6 +17,7 @@ import static extension java.nio.file.Files.list
 @Data
 class TestExecutionKey {
 	static val logger = LoggerFactory.getLogger(TestExecutionKey)
+	static val LOG_FOLDER = 'logs' // TODO replace w/ app config field!!
 
 	static val PATTERN = Pattern.compile('([^-\\s]+)(-([^-\\s]*)(-([^-\\s]*)(-([^-\\s]*))?)?)?')
 	
@@ -110,5 +111,12 @@ class TestExecutionKey {
 		logger.debug('retrieved log file "{}" for test execution key "{}".', logFile.fileName, keyName)
 
 		return logFile
+	}
+	
+	def Iterable<File> getTestFiles(File workspace) {
+		val testPath = workspace.toPath.resolve(LOG_FOLDER)
+		val unfilteredtestFiles = testPath.toFile.listFiles
+		val testFiles = unfilteredtestFiles.filter[name.startsWith('''testrun.«this.toString».''')]
+		return testFiles
 	}
 }

--- a/src/main/java/org/testeditor/web/backend/testexecution/common/TestExecutionKey.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/common/TestExecutionKey.xtend
@@ -6,6 +6,7 @@ import java.io.File
 import java.io.FileNotFoundException
 import java.nio.file.FileSystems
 import java.nio.file.Path
+import java.util.Optional
 import java.util.regex.Pattern
 import org.eclipse.xtend.lib.annotations.Data
 import org.eclipse.xtend.lib.annotations.EqualsHashCode
@@ -57,6 +58,10 @@ class TestExecutionKey {
 			&& ((this.suiteRunId.nullOrEmpty && this.caseRunId.nullOrEmpty && this.callTreeId.nullOrEmpty) || this.suiteRunId == parent.suiteRunId)
 			&& ((this.caseRunId.nullOrEmpty && this.callTreeId.nullOrEmpty) || this.caseRunId == parent.caseRunId)
 			&& (this.callTreeId.nullOrEmpty || this.callTreeId == parent.callTreeId)
+	}
+	
+	def TestExecutionKey deriveWithSuiteRunId() {
+		return new TestExecutionKey(this.suiteId, this.suiteRunId, "", "")
 	}
 	
 	def TestExecutionKey deriveWithSuiteRunId(String suiteRunId) {
@@ -118,5 +123,9 @@ class TestExecutionKey {
 		val unfilteredtestFiles = testPath.toFile.listFiles
 		val testFiles = unfilteredtestFiles.filter[name.startsWith('''testrun.«this.toString».''')]
 		return testFiles
+	}
+	
+	def Optional<File> getLatestCallTree(File workspace) {
+		return Optional.of(workspace.testFiles.filter[name.endsWith('.yaml')].sortBy[name].last)
 	}
 }

--- a/src/main/java/org/testeditor/web/backend/testexecution/common/TestExecutionKey.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/common/TestExecutionKey.xtend
@@ -126,6 +126,6 @@ class TestExecutionKey {
 	}
 	
 	def Optional<File> getLatestCallTree(File workspace) {
-		return Optional.of(workspace.testFiles.filter[name.endsWith('.yaml')].sortBy[name].last)
+		return Optional.ofNullable(workspace.testFiles.filter[name.endsWith('.yaml')].sortBy[name].last)
 	}
 }

--- a/src/main/java/org/testeditor/web/backend/testexecution/distributed/common/TestJobStore.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/distributed/common/TestJobStore.xtend
@@ -8,5 +8,5 @@ interface TestJobStore {
 }
 
 interface WritableTestJobStore extends TestJobStore {
-	def void store(TestExecutionKey key, TestJob job)
+	def void store(TestJobInfo job)
 }

--- a/src/main/java/org/testeditor/web/backend/testexecution/distributed/common/TestJobStore.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/distributed/common/TestJobStore.xtend
@@ -6,3 +6,7 @@ interface TestJobStore {
 	def boolean testJobExists(TestExecutionKey key)
 	def String getJsonCallTree(TestExecutionKey key)
 }
+
+interface WritableTestJobStore extends TestJobStore {
+	def void store(TestExecutionKey key, TestJob job)
+}

--- a/src/main/java/org/testeditor/web/backend/testexecution/distributed/common/TestJobStore.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/distributed/common/TestJobStore.xtend
@@ -1,0 +1,8 @@
+package org.testeditor.web.backend.testexecution.distributed.common
+
+import org.testeditor.web.backend.testexecution.common.TestExecutionKey
+
+interface TestJobStore {
+	def boolean testJobExists(TestExecutionKey key)
+	def String getJsonCallTree(TestExecutionKey key)
+}

--- a/src/main/java/org/testeditor/web/backend/testexecution/distributed/common/TestJobStore.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/distributed/common/TestJobStore.xtend
@@ -1,10 +1,11 @@
 package org.testeditor.web.backend.testexecution.distributed.common
 
+import java.util.Optional
 import org.testeditor.web.backend.testexecution.common.TestExecutionKey
 
 interface TestJobStore {
 	def boolean testJobExists(TestExecutionKey key)
-	def String getJsonCallTree(TestExecutionKey key)
+	def Optional<String> getJsonCallTree(TestExecutionKey key)
 }
 
 interface WritableTestJobStore extends TestJobStore {

--- a/src/main/java/org/testeditor/web/backend/testexecution/distributed/common/Worker.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/distributed/common/Worker.xtend
@@ -13,7 +13,7 @@ interface WorkerInfo {
 
 }
 
-interface Worker extends RunningTest, WorkerInfo {
+interface Worker extends RunningTest, WorkerInfo, TestJobStore {
 
 	def CompletionStage<Boolean> startJob(TestJobInfo job)
 

--- a/src/main/java/org/testeditor/web/backend/testexecution/distributed/manager/LocalSingleWorkerJobStore.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/distributed/manager/LocalSingleWorkerJobStore.xtend
@@ -38,7 +38,12 @@ class LocalSingleWorkerJobStore implements WritableTestJobStore {
 	}
 	
 	override getJsonCallTree(TestExecutionKey key) {
-		callTreeMap.get(key).map[callTreeHelper.getNodeJson(key)[it]].orElse('')
+		if (key.caseRunId.nullOrEmpty) {
+			callTreeMap.get(key).map[key.getCompleteTestCallTreeJson[it]]
+		} else {
+			callTreeMap.get(key.deriveWithSuiteRunId).map[key.getNodeJson[it]]
+		}
+		
 	}
 	
 	override store(TestJobInfo job) {

--- a/src/main/java/org/testeditor/web/backend/testexecution/distributed/manager/LocalSingleWorkerJobStore.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/distributed/manager/LocalSingleWorkerJobStore.xtend
@@ -1,21 +1,38 @@
 package org.testeditor.web.backend.testexecution.distributed.manager
 
 import com.google.common.cache.CacheBuilder
+import java.io.File
+import java.util.List
 import javax.inject.Inject
+import javax.inject.Named
+import javax.inject.Provider
+import org.testeditor.web.backend.testexecution.TestExecutionCallTree
+import org.testeditor.web.backend.testexecution.common.TestExecutionConfiguration
 import org.testeditor.web.backend.testexecution.common.TestExecutionKey
 import org.testeditor.web.backend.testexecution.distributed.common.TestJob
+import org.testeditor.web.backend.testexecution.distributed.common.TestJobInfo
 import org.testeditor.web.backend.testexecution.distributed.common.WritableTestJobStore
 import org.testeditor.web.backend.testexecution.util.serialization.YamlReader
 
 class LocalSingleWorkerJobStore implements WritableTestJobStore {
-	@Inject YamlReader yamlReader
+	@Inject extension YamlReader
+	@Inject extension TestExecutionCallTree callTreeHelper
+	@Inject @Named('workspace') File workspace
 	
-	val jobCache = CacheBuilder.newBuilder.maximumSize(1000).build[TestExecutionKey key|
-		
+	@Inject Provider<TestExecutionConfiguration> config
+	val jobCache = CacheBuilder.newBuilder.maximumSize(1000).<TestExecutionKey, TestJobInfo>build[key|
+		callTreeMap.get(key)
+		/* TODO capabilities need to be stored in call tree yaml! */
+		.map[new TestJob(key, #{}, getOrDefault('resourcePaths',#[]) as List<String>)]
+		.orElse(TestJob.NONE)
+	]
+	
+	val callTreeMap = CacheBuilder.newBuilder.maximumSize(1000).build[TestExecutionKey key|
+		key.getLatestCallTree(workspace).map[readYaml]
 	]
 	
 	override testJobExists(TestExecutionKey key) {
-		
+		jobCache.get(key.deriveWithSuiteRunId) != TestJob.NONE
 	}
 	
 	override getJsonCallTree(TestExecutionKey key) {

--- a/src/main/java/org/testeditor/web/backend/testexecution/distributed/manager/LocalSingleWorkerJobStore.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/distributed/manager/LocalSingleWorkerJobStore.xtend
@@ -1,0 +1,29 @@
+package org.testeditor.web.backend.testexecution.distributed.manager
+
+import com.google.common.cache.CacheBuilder
+import javax.inject.Inject
+import org.testeditor.web.backend.testexecution.common.TestExecutionKey
+import org.testeditor.web.backend.testexecution.distributed.common.TestJob
+import org.testeditor.web.backend.testexecution.distributed.common.WritableTestJobStore
+import org.testeditor.web.backend.testexecution.util.serialization.YamlReader
+
+class LocalSingleWorkerJobStore implements WritableTestJobStore {
+	@Inject YamlReader yamlReader
+	
+	val jobCache = CacheBuilder.newBuilder.maximumSize(1000).build[TestExecutionKey key|
+		
+	]
+	
+	override testJobExists(TestExecutionKey key) {
+		
+	}
+	
+	override getJsonCallTree(TestExecutionKey key) {
+		throw new UnsupportedOperationException("TODO: auto-generated method stub")
+	}
+	
+	override store(TestExecutionKey key, TestJob job) {
+		throw new UnsupportedOperationException("TODO: auto-generated method stub")
+	}
+	
+}

--- a/src/main/java/org/testeditor/web/backend/testexecution/distributed/manager/LocalSingleWorkerJobStore.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/distributed/manager/LocalSingleWorkerJobStore.xtend
@@ -36,11 +36,11 @@ class LocalSingleWorkerJobStore implements WritableTestJobStore {
 	}
 	
 	override getJsonCallTree(TestExecutionKey key) {
-		throw new UnsupportedOperationException("TODO: auto-generated method stub")
+		callTreeMap.get(key).map[callTreeHelper.getNodeJson(key)[it]].orElse('')
 	}
 	
-	override store(TestExecutionKey key, TestJob job) {
-		throw new UnsupportedOperationException("TODO: auto-generated method stub")
+	override store(TestJobInfo job) {
+		jobCache.put(job.id, job)
 	}
 	
 }

--- a/src/main/java/org/testeditor/web/backend/testexecution/distributed/manager/LocalSingleWorkerJobStore.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/distributed/manager/LocalSingleWorkerJobStore.xtend
@@ -17,7 +17,9 @@ import org.testeditor.web.backend.testexecution.util.serialization.YamlReader
 class LocalSingleWorkerJobStore implements WritableTestJobStore {
 	@Inject extension YamlReader
 	@Inject extension TestExecutionCallTree callTreeHelper
-	@Inject @Named('workspace') File workspace
+	@Inject @Named('workspace') Provider<File> workspaceProvider
+	
+	private def workspace() { workspaceProvider.get }
 	
 	@Inject Provider<TestExecutionConfiguration> config
 	val jobCache = CacheBuilder.newBuilder.maximumSize(1000).<TestExecutionKey, TestJobInfo>build[key|

--- a/src/main/java/org/testeditor/web/backend/testexecution/distributed/manager/LocalSingleWorkerManager.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/distributed/manager/LocalSingleWorkerManager.xtend
@@ -1,13 +1,15 @@
 package org.testeditor.web.backend.testexecution.distributed.manager
 
 import javax.inject.Inject
+import org.eclipse.xtend.lib.annotations.Delegate
 import org.testeditor.web.backend.testexecution.distributed.common.TestJob
+import org.testeditor.web.backend.testexecution.distributed.common.TestJobStore
 import org.testeditor.web.backend.testexecution.distributed.common.Worker
 import org.testeditor.web.backend.testexecution.distributed.common.WorkerInfo
 
 class LocalSingleWorkerManager implements WorkerProvider {
 
-	@Inject Worker worker
+	@Inject @Delegate(TestJobStore) Worker worker
 
 	override getWorkers() {
 		return #[worker]

--- a/src/main/java/org/testeditor/web/backend/testexecution/distributed/manager/TestExecutionManager.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/distributed/manager/TestExecutionManager.xtend
@@ -22,7 +22,7 @@ interface TestExecutionManager extends TestJobStore {
 @Singleton
 class LocalSingleWorkerExecutionManager implements TestExecutionManager {
 	@Inject extension WorkerProvider workerProvider
-	@Inject @Delegate(TestJobStore) extension WritableTestJobStore jobStore
+	@Inject extension WritableTestJobStore jobStore
 	
 	var Optional<TestJobInfo> currentJob = Optional.empty
 
@@ -39,4 +39,13 @@ class LocalSingleWorkerExecutionManager implements TestExecutionManager {
 		workers.head.assign(it)
 		currentJob = Optional.of(it)
 	}
+	
+	override testJobExists(TestExecutionKey key) {
+		jobStore.testJobExists(key) || workerProvider.testJobExists(key)
+	}
+	
+	override getJsonCallTree(TestExecutionKey key) {
+		jobStore.getJsonCallTree(key).or[workerProvider.getJsonCallTree(key)]
+	}
+	
 }

--- a/src/main/java/org/testeditor/web/backend/testexecution/distributed/manager/TestExecutionManager.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/distributed/manager/TestExecutionManager.xtend
@@ -22,28 +22,21 @@ interface TestExecutionManager extends TestJobStore {
 @Singleton
 class LocalSingleWorkerExecutionManager implements TestExecutionManager {
 	@Inject extension WorkerProvider workerProvider
-	@Inject @Delegate(TestJobStore) WritableTestJobStore jobStore
+	@Inject @Delegate(TestJobStore) extension WritableTestJobStore jobStore
 	
-	var Optional<TestExecutionKey> currentJob = Optional.empty
+	var Optional<TestJobInfo> currentJob = Optional.empty
 
 	override cancelJob(TestExecutionKey key) {
-		currentJob.filter[it == key].ifPresent[
+		currentJob.filter[id == key].ifPresent[
 			workers.head.cancel
+			setState(JobState.COMPLETED).store
 			currentJob = Optional.empty
-			jobLog.computeIfPresent(key)[__, job|job.setState(JobState.COMPLETED)]
 		]
 	}
 
 	override addJob(TestJob it) {
-		jobLog.put(id, it)
+		store
 		workers.head.assign(it)
-		currentJob = Optional.of(id)
+		currentJob = Optional.of(it)
 	}
-	
-	override boolean testJobExists(TestExecutionKey key) {
-		jobLog.computeIfAbsent(key)[
-			
-		] !== TestJob.NONE
-	}
-
 }

--- a/src/main/java/org/testeditor/web/backend/testexecution/distributed/manager/TestExecutionManager.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/distributed/manager/TestExecutionManager.xtend
@@ -9,6 +9,7 @@ import org.testeditor.web.backend.testexecution.distributed.common.TestJob
 import org.testeditor.web.backend.testexecution.distributed.common.TestJobInfo
 import org.testeditor.web.backend.testexecution.distributed.common.TestJobInfo.JobState
 import org.testeditor.web.backend.testexecution.distributed.common.TestJobStore
+import org.testeditor.web.backend.testexecution.distributed.common.WritableTestJobStore
 
 interface TestExecutionManager extends TestJobStore {
 
@@ -20,9 +21,9 @@ interface TestExecutionManager extends TestJobStore {
 
 @Singleton
 class LocalSingleWorkerExecutionManager implements TestExecutionManager {
-	@Inject @Delegate(TestJobStore) extension WorkerProvider workerProvider
-
-	val jobLog = <TestExecutionKey, TestJobInfo>newHashMap
+	@Inject extension WorkerProvider workerProvider
+	@Inject @Delegate(TestJobStore) WritableTestJobStore jobStore
+	
 	var Optional<TestExecutionKey> currentJob = Optional.empty
 
 	override cancelJob(TestExecutionKey key) {
@@ -37,6 +38,12 @@ class LocalSingleWorkerExecutionManager implements TestExecutionManager {
 		jobLog.put(id, it)
 		workers.head.assign(it)
 		currentJob = Optional.of(id)
+	}
+	
+	override boolean testJobExists(TestExecutionKey key) {
+		jobLog.computeIfAbsent(key)[
+			
+		] !== TestJob.NONE
 	}
 
 }

--- a/src/main/java/org/testeditor/web/backend/testexecution/distributed/manager/WorkerProvider.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/distributed/manager/WorkerProvider.xtend
@@ -1,9 +1,10 @@
 package org.testeditor.web.backend.testexecution.distributed.manager
 
 import org.testeditor.web.backend.testexecution.distributed.common.TestJob
+import org.testeditor.web.backend.testexecution.distributed.common.TestJobStore
 import org.testeditor.web.backend.testexecution.distributed.common.WorkerInfo
 
-interface WorkerProvider {
+interface WorkerProvider extends TestJobStore {
 
 	def Iterable<WorkerInfo> getWorkers()
 

--- a/src/main/java/org/testeditor/web/backend/testexecution/distributed/worker/LocalSingleWorker.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/distributed/worker/LocalSingleWorker.xtend
@@ -75,8 +75,12 @@ class LocalSingleWorker implements Worker {
 	
 	override getJsonCallTree(TestExecutionKey key) {
 		val latestCallTree = executorProvider.getTestFiles(new TestExecutionKey(key.suiteId, key.suiteRunId)).filter[name.endsWith('.yaml')].sortBy[name].last
-		testExecutionCallTree.readFile(key, latestCallTree)
-		return testExecutionCallTree.getNodeJson(key)
+		return if (latestCallTree !== null) {
+			testExecutionCallTree.readFile(key, latestCallTree)
+			testExecutionCallTree.getNodeJson(key)
+		} else { 
+			null // TODO throw exception instead!!
+		}
 	}
 	
 	override testJobExists(TestExecutionKey key) {

--- a/src/main/java/org/testeditor/web/backend/testexecution/distributed/worker/LocalSingleWorker.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/distributed/worker/LocalSingleWorker.xtend
@@ -19,6 +19,7 @@ import org.testeditor.web.backend.testexecution.util.CallTreeYamlUtil
 
 import static org.testeditor.web.backend.testexecution.TestExecutorProvider.CALL_TREE_YAML_FILE
 import static org.testeditor.web.backend.testexecution.TestExecutorProvider.LOGFILE_ENV_KEY
+import javax.inject.Named
 
 class LocalSingleWorker implements Worker {
 	static val logger = LoggerFactory.getLogger(LocalSingleWorker)
@@ -28,6 +29,7 @@ class LocalSingleWorker implements Worker {
 	@Inject Provider<TestExecutorProvider> _executorProvider // eager initialization causes injection trouble due to Dropwizard env not being set
 	@Inject extension TestLogWriter
 	@Inject extension CallTreeYamlUtil
+	@Inject @Named('workspace') Provider<File> workspace
 	
 	var Optional<TestJobInfo> currentJob = Optional.empty
 	
@@ -74,7 +76,7 @@ class LocalSingleWorker implements Worker {
 	}
 	
 	override getJsonCallTree(TestExecutionKey key) {
-		val latestCallTree = executorProvider.getTestFiles(new TestExecutionKey(key.suiteId, key.suiteRunId)).filter[name.endsWith('.yaml')].sortBy[name].last
+		val latestCallTree = new TestExecutionKey(key.suiteId, key.suiteRunId).getTestFiles(workspace.get).filter[name.endsWith('.yaml')].sortBy[name].last
 		return if (latestCallTree !== null) {
 			testExecutionCallTree.readFile(key, latestCallTree)
 			testExecutionCallTree.getNodeJson(key)

--- a/src/main/java/org/testeditor/web/backend/testexecution/distributed/worker/LocalSingleWorker.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/distributed/worker/LocalSingleWorker.xtend
@@ -43,7 +43,7 @@ class LocalSingleWorker implements Worker {
 		logger.
 			info('''Starting test for resourcePaths='«resourcePaths.join(',')»' logging into logFile='«logFile»', callTreeFile='«callTreeFileName»'.''')
 		val callTreeFile = new File(callTreeFileName)
-		callTreeFile.writeCallTreeYamlPrefix(executorProvider.yamlFileHeader(id, Instant.now, resourcePaths))
+		callTreeFile.writeCallTreeYamlPrefix(id, Instant.now, resourcePaths)
 		val testProcess = builder.start
 		statusMapper.addTestSuiteRun(id, testProcess)[status|callTreeFile.writeCallTreeYamlSuffix(status)]
 		testProcess.logToStandardOutAndIntoFile(new File(logFile))

--- a/src/main/java/org/testeditor/web/backend/testexecution/dropwizard/LocalSingleWorkerModule.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/dropwizard/LocalSingleWorkerModule.xtend
@@ -2,7 +2,9 @@ package org.testeditor.web.backend.testexecution.dropwizard
 
 import com.google.inject.AbstractModule
 import org.testeditor.web.backend.testexecution.distributed.common.Worker
+import org.testeditor.web.backend.testexecution.distributed.common.WritableTestJobStore
 import org.testeditor.web.backend.testexecution.distributed.manager.LocalSingleWorkerExecutionManager
+import org.testeditor.web.backend.testexecution.distributed.manager.LocalSingleWorkerJobStore
 import org.testeditor.web.backend.testexecution.distributed.manager.LocalSingleWorkerManager
 import org.testeditor.web.backend.testexecution.distributed.manager.TestExecutionManager
 import org.testeditor.web.backend.testexecution.distributed.manager.WorkerProvider
@@ -14,6 +16,7 @@ class LocalSingleWorkerModule extends AbstractModule {
 			bind(TestExecutionManager).to(LocalSingleWorkerExecutionManager)
 			bind(WorkerProvider).to(LocalSingleWorkerManager)
 			bind(Worker).to(LocalSingleWorker)
+			bind(WritableTestJobStore).to(LocalSingleWorkerJobStore)
 		]
 	}
 }

--- a/src/main/java/org/testeditor/web/backend/testexecution/dropwizard/TestExecutionDropwizardConfiguration.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/dropwizard/TestExecutionDropwizardConfiguration.xtend
@@ -42,5 +42,11 @@ class TestExecutionDropwizardConfiguration extends DropwizardApplicationConfigur
 	
     @Accessors
     Boolean filterTestSubStepsFromLogs = false
+    
+    @Accessors
+    int testJobCacheSize = 1000
+    
+	@Accessors 
+	int testJobCallTreeCacheSize = 10
 
 }

--- a/src/main/java/org/testeditor/web/backend/testexecution/git/GitProvider.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/git/GitProvider.xtend
@@ -6,6 +6,7 @@ import com.jcraft.jsch.JSchException
 import com.jcraft.jsch.Session
 import java.io.File
 import javax.inject.Inject
+import javax.inject.Provider
 import org.eclipse.jgit.api.CreateBranchCommand
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.api.GitCommand
@@ -28,7 +29,9 @@ class GitProvider {
 		initialize(workspace)
 	]
 
-	@Inject GitConfiguration config
+	@Inject Provider<GitConfiguration> _config
+	
+	private def config() { _config.get }
 
 	/**
 	 * @return the potentially cached {@link Git} instance for the current workspace.

--- a/src/main/java/org/testeditor/web/backend/testexecution/screenshots/SubStepAggregatingScreenshotFinder.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/screenshots/SubStepAggregatingScreenshotFinder.xtend
@@ -6,6 +6,7 @@ import javax.inject.Inject
 import javax.inject.Named
 import org.testeditor.web.backend.testexecution.TestExecutionCallTree
 import org.testeditor.web.backend.testexecution.common.TestExecutionKey
+import org.testeditor.web.backend.testexecution.util.serialization.YamlReader
 
 class SubStepAggregatingScreenshotFinder implements ScreenshotFinder {
 
@@ -15,19 +16,18 @@ class SubStepAggregatingScreenshotFinder implements ScreenshotFinder {
 	TestExecutionCallTree callTree
 	@Inject @Named('workspace')
 	File workspace
+	@Inject
+	extension YamlReader
 
 	override getScreenshotPathsForTestStep(TestExecutionKey key) {
-		var result = delegateFinder.getScreenshotPathsForTestStep(key)
-		if (result.nullOrEmpty) {
-			val latestCallTree = new TestExecutionKey(key.suiteId, key.suiteRunId).getTestFiles(workspace) //
-			.filter[name.endsWith('.yaml')].sortBy[name].last
-			callTree.readFile(key, latestCallTree)
-
-			result = callTree.getDescendantsKeys(key) //
-			.map[delegateFinder.getScreenshotPathsForTestStep(it)] //
-			.reduce[list1, list2|list1 + list2]
-		}
-		return Optional.ofNullable(result).orElse(#[])
+		return Optional.ofNullable(delegateFinder.getScreenshotPathsForTestStep(key)).filter[!empty].or[
+			val latestCallTree = key.deriveWithSuiteRunId.getLatestCallTree(workspace) //
+			latestCallTree.map[
+				callTree.getDescendantsKeys(key)[readYaml] //
+					.map[delegateFinder.getScreenshotPathsForTestStep(it)] //
+					.reduce[list1, list2|list1 + list2]
+			]
+		].orElse(#[])
 	}
 
 }

--- a/src/main/java/org/testeditor/web/backend/testexecution/screenshots/SubStepAggregatingScreenshotFinder.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/screenshots/SubStepAggregatingScreenshotFinder.xtend
@@ -1,9 +1,10 @@
 package org.testeditor.web.backend.testexecution.screenshots
 
+import java.io.File
 import java.util.Optional
 import javax.inject.Inject
+import javax.inject.Named
 import org.testeditor.web.backend.testexecution.TestExecutionCallTree
-import org.testeditor.web.backend.testexecution.TestExecutorProvider
 import org.testeditor.web.backend.testexecution.common.TestExecutionKey
 
 class SubStepAggregatingScreenshotFinder implements ScreenshotFinder {
@@ -12,13 +13,13 @@ class SubStepAggregatingScreenshotFinder implements ScreenshotFinder {
 	TestArtifactRegistryScreenshotFinder delegateFinder
 	@Inject
 	TestExecutionCallTree callTree
-	@Inject
-	TestExecutorProvider executorProvider
+	@Inject @Named('workspace')
+	File workspace
 
 	override getScreenshotPathsForTestStep(TestExecutionKey key) {
 		var result = delegateFinder.getScreenshotPathsForTestStep(key)
 		if (result.nullOrEmpty) {
-			val latestCallTree = executorProvider.getTestFiles(new TestExecutionKey(key.suiteId, key.suiteRunId)) //
+			val latestCallTree = new TestExecutionKey(key.suiteId, key.suiteRunId).getTestFiles(workspace) //
 			.filter[name.endsWith('.yaml')].sortBy[name].last
 			callTree.readFile(key, latestCallTree)
 

--- a/src/main/java/org/testeditor/web/backend/testexecution/util/CallTreeYamlUtil.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/util/CallTreeYamlUtil.xtend
@@ -2,8 +2,12 @@ package org.testeditor.web.backend.testexecution.util
 
 import java.io.File
 import java.nio.file.Files
+import java.time.Instant
 import javax.inject.Singleton
+import org.apache.commons.text.StringEscapeUtils
+import org.testeditor.web.backend.testexecution.common.TestExecutionKey
 import org.testeditor.web.backend.testexecution.common.TestStatus
+import org.testeditor.web.backend.testexecution.distributed.common.TestJob
 
 import static java.nio.charset.StandardCharsets.UTF_8
 import static java.nio.file.StandardOpenOption.APPEND
@@ -16,6 +20,20 @@ class CallTreeYamlUtil {
 		callTreeYamlFile.parentFile.mkdirs
 		Files.write(callTreeYamlFile.toPath, fileHeader.getBytes(UTF_8), CREATE, TRUNCATE_EXISTING)
 		return callTreeYamlFile
+	}
+	
+	def File writeCallTreeYamlPrefix(File callTreeYamlFile, TestExecutionKey executionKey, Instant instant, Iterable<String> resourcePaths) {
+		writeCallTreeYamlPrefix(callTreeYamlFile, yamlFileHeader(executionKey, instant, resourcePaths))
+	}
+	
+	def String yamlFileHeader(TestExecutionKey executionKey, Instant instant, Iterable<String> resourcePaths) {
+		return '''
+			"started": "«StringEscapeUtils.escapeJava(instant.toString)»"
+			"testSuiteId": "«StringEscapeUtils.escapeJava(executionKey.suiteId)»"
+			"testSuiteRunId": "«StringEscapeUtils.escapeJava(executionKey.suiteRunId)»"
+			"resourcePaths": [ «resourcePaths.map['"'+StringEscapeUtils.escapeJava(it)+'"'].join(", ")» ]
+			"testRuns":
+		'''
 	}
 
 	def void writeCallTreeYamlSuffix(File callTreeYamlFile, TestStatus testStatus) {

--- a/src/main/java/org/testeditor/web/backend/testexecution/webapi/TestSuiteResource.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/webapi/TestSuiteResource.xtend
@@ -130,13 +130,10 @@ class TestSuiteResource {
 			}
 		} else {
 			// get the latest call tree of the given resource
-			val latestCallTree = executorProvider.getTestFiles(new TestExecutionKey(suiteId, suiteRunId)).filter[name.endsWith('.yaml')].sortBy[name].
-				reverse.head
+			val latestCallTree = manager.getJsonCallTree(new TestExecutionKey(suiteId, suiteRunId))
 			if (latestCallTree !== null) {
-				val mapper = new ObjectMapper(new YAMLFactory)
-				val jsonTree = mapper.readTree(latestCallTree)
 				response.resume(
-					Response.ok(jsonTree.toString).build
+					Response.ok(latestCallTree).build
 				)
 			} else {
 				response.resume(

--- a/src/main/java/org/testeditor/web/backend/testexecution/webapi/TestSuiteResource.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/webapi/TestSuiteResource.xtend
@@ -23,7 +23,6 @@ import javax.ws.rs.core.Response
 import javax.ws.rs.core.Response.Status
 import javax.ws.rs.core.UriBuilder
 import org.slf4j.LoggerFactory
-import org.testeditor.web.backend.testexecution.TestExecutorProvider
 import org.testeditor.web.backend.testexecution.TestStatusMapper
 import org.testeditor.web.backend.testexecution.TestSuiteStatusInfo
 import org.testeditor.web.backend.testexecution.common.TestExecutionKey
@@ -45,7 +44,6 @@ class TestSuiteResource {
 	public static val LONG_POLLING_TIMEOUT_SECONDS = 5
 	static val logger = LoggerFactory.getLogger(TestSuiteResource)
 
-	@Inject TestExecutorProvider executorProvider
 	@Inject TestStatusMapper statusMapper
 	@Inject Executor executor
 	@Inject ScreenshotFinder screenshotFinder

--- a/src/main/java/org/testeditor/web/backend/testexecution/webapi/TestSuiteResource.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/webapi/TestSuiteResource.xtend
@@ -1,7 +1,5 @@
 package org.testeditor.web.backend.testexecution.webapi
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import java.io.FileNotFoundException
 import java.net.URI
 import java.net.URLEncoder

--- a/src/main/java/org/testeditor/web/backend/testexecution/workspace/WorkspaceProvider.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/workspace/WorkspaceProvider.xtend
@@ -18,9 +18,11 @@ class WorkspaceProvider implements Provider<File> {
 
 	static val logger = LoggerFactory.getLogger(WorkspaceProvider)
 
-	@Inject extension GitConfiguration
+	@Inject Provider<GitConfiguration> _gitConfiguration
 	@Inject extension GitProvider
 	@Inject Provider<User> userProvider
+	
+	private def localRepoFileRoot() { _gitConfiguration.get.localRepoFileRoot }
 
 	override get() {
 		return new File(localRepoFileRoot) => [

--- a/src/main/resources/META-INF/deptective.json
+++ b/src/main/resources/META-INF/deptective.json
@@ -2,130 +2,217 @@
 	"components": [
 		{
 			"name": "DropwizardApplication",
-			"contains": ["org.testeditor.web.backend.testexecution.dropwizard"],
-			"reads": ["Apache Commons IO",
-                      "CommonAPI", 
-                      "Commons", 
-                      "Dropwizard",
-                      "GitAccess",
-                      "Guice",
-                      "IO", 
-                      "TestEditorDropwizard",
-                      "TestExecutionManager",
-                      "TestExecutionWorker",
-			          "TestProcessExecution",
-			          "WebAPI"]
+			"contains": [
+				"org.testeditor.web.backend.testexecution.dropwizard"
+			],
+			"reads": [
+				"Apache Commons IO",
+				"CommonAPI",
+				"Commons",
+				"Dropwizard",
+				"GitAccess",
+				"Guice",
+				"IO",
+				"TestEditorDropwizard",
+				"TestExecutionManager",
+				"TestExecutionWorker",
+				"TestProcessExecution",
+				"WebAPI",
+				"Workspace"
+			]
 		},
 		{
 			"name": "WebAPI",
-			"contains": ["org.testeditor.web.backend.testexecution.webapi"],
-			"reads": ["TestExecutionManager", "CommonAPI", "Commons", "Dropwizard", "JAX-RS", "Jackson", "IO", "Network"
+			"contains": [
+				"org.testeditor.web.backend.testexecution.webapi"
+			],
+			"reads": [
+				"TestExecutionManager",
+				"CommonAPI",
+				"Commons",
+				"Dropwizard",
+				"JAX-RS",
+				"Jackson",
+				"IO",
+				"Network",
+				"Workspace"
 			]
 		},
 		{
 			"name": "CommonAPI",
-			"contains": ["org.testeditor.web.backend.testexecution.distributed.common"],
-			"reads": ["Commons", "Jackson", "Network"]
+			"contains": [
+				"org.testeditor.web.backend.testexecution.distributed.common"
+			],
+			"reads": [
+				"Commons",
+				"Jackson",
+				"Network"
+			]
 		},
 		{
 			"name": "TestExecutionManager",
-			"contains": ["org.testeditor.web.backend.testexecution.distributed.manager"],
-			"reads": ["CommonAPI", "Commons"]
+			"contains": [
+				"org.testeditor.web.backend.testexecution.distributed.manager"
+			],
+			"reads": [
+				"CommonAPI",
+				"Commons"
+			]
 		},
 		{
 			"name": "TestExecutionWorker",
-			"contains": ["org.testeditor.web.backend.testexecution.distributed.worker"],
-			"reads": ["CommonAPI", "TestProcessExecution", "Commons", "IO", "Network"]
+			"contains": [
+				"org.testeditor.web.backend.testexecution.distributed.worker"
+			],
+			"reads": [
+				"CommonAPI",
+				"TestProcessExecution",
+				"Commons",
+				"IO",
+				"Network"
+			]
 		},
 		{
 			"name": "TestProcessExecution",
-			"contains": ["org.testeditor.web.backend.testexecution",
-				         "org.testeditor.web.backend.testexecution.loglines",
-				         "org.testeditor.web.backend.testexecution.screenshots",
-				         "org.testeditor.web.backend.testexecution.workspace"
+			"contains": [
+				"org.testeditor.web.backend.testexecution",
+				"org.testeditor.web.backend.testexecution.loglines",
+				"org.testeditor.web.backend.testexecution.screenshots"
 			],
-			"reads": ["GitAccess", "Commons", "IO", "TestEditorDropwizard", "ApacheCommonsText", "ApacheCommonsLang"]
+			"reads": [
+				"GitAccess",
+				"Commons",
+				"IO",
+				"TestEditorDropwizard",
+				"ApacheCommonsText",
+				"ApacheCommonsLang"
+			]
+		},
+		{
+			"name": "Workspace",
+			"contains": [
+				"org.testeditor.web.backend.testexecution.workspace"
+			],
+			"reads": [
+				"GitAccess",
+				"Commons",
+				"IO",
+				"TestEditorDropwizard"
+			]
 		},
 		{
 			"name": "GitAccess",
-			"contains": ["org.testeditor.web.backend.testexecution.git",
-			             "com.jcraft.jsch",
-			             "org.eclipse.jgit.api",
-			             "org.eclipse.jgit.lib",
-			             "org.eclipse.jgit.transport",
-			             "org.eclipse.jgit.util"],
-            "reads": ["Commons", "IO"]
+			"contains": [
+				"org.testeditor.web.backend.testexecution.git",
+				"com.jcraft.jsch",
+				"org.eclipse.jgit.api",
+				"org.eclipse.jgit.lib",
+				"org.eclipse.jgit.transport",
+				"org.eclipse.jgit.util"
+			],
+			"reads": [
+				"Commons",
+				"IO"
+			]
 		},
 		{
 			"name": "Commons",
-			"contains": ["org.testeditor.web.backend.testexecution.common",
-			             "org.testeditor.web.backend.testexecution.util",
-			             "org.testeditor.web.backend.testexecution.util.serialization"],
-			"reads": ["IO", "Jackson"]
+			"contains": [
+				"org.testeditor.web.backend.testexecution.common",
+				"org.testeditor.web.backend.testexecution.util",
+				"org.testeditor.web.backend.testexecution.util.serialization"
+			],
+			"reads": [
+				"IO",
+				"Jackson"
+			]
 		},
 		{
 			"name": "TestEditorDropwizard",
-			"contains": ["org.testeditor.web.dropwizard*"]
+			"contains": [
+				"org.testeditor.web.dropwizard*"
+			]
 		},
 		{
 			"name": "Dropwizard",
-			"contains": ["com.codahale.metrics.health",
-					     "io.dropwizard*",
-					     "javax.servlet",
-					     "org.eclipse.jetty.servlets"]
+			"contains": [
+				"com.codahale.metrics.health",
+				"io.dropwizard*",
+				"javax.servlet",
+				"org.eclipse.jetty.servlets"
+			]
 		},
 		{
 			"name": "Guice",
-			"contains": ["com.google.inject", "com.google.inject.name"]
+			"contains": [
+				"com.google.inject",
+				"com.google.inject.name"
+			]
 		},
 		{
 			"name": "JAX-RS",
-			"contains": ["javax.ws.rs", "javax.ws.rs.container", "javax.ws.rs.core", "javax.ws.rs.ext", "javax.ws.rs.container.ext"]
+			"contains": [
+				"javax.ws.rs",
+				"javax.ws.rs.container",
+				"javax.ws.rs.core",
+				"javax.ws.rs.ext",
+				"javax.ws.rs.container.ext"
+			]
 		},
 		{
 			"name": "Jackson",
-			"contains": ["com.fasterxml.jackson.core.util", "com.fasterxml.jackson.databind", "com.fasterxml.jackson.dataformat.yaml"]
+			"contains": [
+				"com.fasterxml.jackson.core.util",
+				"com.fasterxml.jackson.databind",
+				"com.fasterxml.jackson.dataformat.yaml"
+			]
 		},
 		{
 			"name": "ApacheCommonsLang",
-			"contains": ["org.apache.commons.lang3"]
+			"contains": [
+				"org.apache.commons.lang3"
+			]
 		},
 		{
 			"name": "ApacheCommonsText",
-			"contains": ["org.apache.commons.text"]
+			"contains": [
+				"org.apache.commons.text"
+			]
 		},
 		{
 			"name": "IO",
-			"contains": ["java.io", "java.nio*", "org.apache.commons.io", "org.apache.commons.io.output"]
+			"contains": [
+				"java.io",
+				"java.nio*",
+				"org.apache.commons.io",
+				"org.apache.commons.io.output"
+			]
 		},
 		{
 			"name": "Network",
-			"contains": ["java.net*"]
+			"contains": [
+				"java.net*"
+			]
 		}
 	],
-	"whitelisted" : [
+	"whitelisted": [
 		"### JSON annotations ###",
 		"com.fasterxml.jackson.annotation*",
-		
 		"com.google.common*",
-		
 		"### JDK utilities ###",
 		"java.time*",
 		"java.util*",
-		
 		"### dependency injection ###",
 		"javax.inject",
-		
 		"### Bean Validation API ###",
 		"javax.validation*",
-		
+		"# Hibernate Validator should be removed once Dropwizard 2.x is used, which includes Bean Validation 2.0",
+		"org.hibernate.validator.constraints",
 		"### utilities used by Xtend-to-Java code generation ###",
 		"org.eclipse.xtend*",
 		"org.eclipse.xtend2*",
 		"org.eclipse.xtext.xbase*",
-		
 		"### logging framework SLF4J ###",
 		"org.slf4j"
-
 	]
 }

--- a/src/test/java/org/testeditor/web/backend/testexecution/TestExecutorProviderTest.xtend
+++ b/src/test/java/org/testeditor/web/backend/testexecution/TestExecutorProviderTest.xtend
@@ -2,15 +2,12 @@ package org.testeditor.web.backend.testexecution
 
 import java.time.Instant
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.mockito.InjectMocks
-import org.mockito.junit.MockitoJUnitRunner
 import org.testeditor.web.backend.testexecution.common.TestExecutionKey
+import org.testeditor.web.backend.testexecution.util.CallTreeYamlUtil
 
-@RunWith(MockitoJUnitRunner)
 class TestExecutorProviderTest {
 
-	@InjectMocks TestExecutorProvider testExecutorProviderUnderTest
+	val callTreeYamlUtil = new CallTreeYamlUtil
 
 	@Test
 	def void testYamlHeaderDoesEscaping() {
@@ -23,7 +20,7 @@ class TestExecutorProviderTest {
 		val now = Instant.now
 
 		// when
-		val result = testExecutorProviderUnderTest.yamlFileHeader(executionKey, now, resourcePaths)
+		val result = callTreeYamlUtil.yamlFileHeader(executionKey, now, resourcePaths)
 
 		// then
 		result.equals('''

--- a/src/test/java/org/testeditor/web/backend/testexecution/screenshots/SubStepAggregatingScreenshotFinderTest.xtend
+++ b/src/test/java/org/testeditor/web/backend/testexecution/screenshots/SubStepAggregatingScreenshotFinderTest.xtend
@@ -1,23 +1,22 @@
 package org.testeditor.web.backend.testexecution.screenshots
 
+import java.io.File
+import java.util.Optional
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.testeditor.web.backend.testexecution.TestExecutionCallTree
-import org.testeditor.web.backend.testexecution.TestExecutorProvider
 import org.testeditor.web.backend.testexecution.common.TestExecutionKey
+import org.testeditor.web.backend.testexecution.util.serialization.YamlReader
 
 import static org.assertj.core.api.Assertions.assertThat
 import static org.mockito.ArgumentMatchers.*
-import static org.mockito.Mockito.mock
-import static org.mockito.Mockito.when
 import static org.mockito.Mockito.doReturn
+import static org.mockito.Mockito.mock
 import static org.mockito.Mockito.spy
-import java.util.Optional
-import java.io.File
-import org.testeditor.web.backend.testexecution.util.serialization.YamlReader
+import static org.mockito.Mockito.when
 
 @RunWith(MockitoJUnitRunner)
 class SubStepAggregatingScreenshotFinderTest {
@@ -37,9 +36,7 @@ class SubStepAggregatingScreenshotFinderTest {
 		
 		doReturn(key).when(key).deriveWithSuiteRunId
 		doReturn(Optional.of(mock(File))).when(key).getLatestCallTree(any)
-		
-		when(mockYamlReader.readYaml(any(File))).thenReturn(#{})
-		
+				
 		when(mockDelegate.getScreenshotPathsForTestStep(key)).thenReturn(#[])
 		childKeys.forEach[when(mockDelegate.getScreenshotPathsForTestStep(it)).thenReturn(#['''path/to/screenshot-«callTreeId».png'''])]
 		

--- a/src/test/java/org/testeditor/web/backend/testexecution/screenshots/SubStepAggregatingScreenshotFinderTest.xtend
+++ b/src/test/java/org/testeditor/web/backend/testexecution/screenshots/SubStepAggregatingScreenshotFinderTest.xtend
@@ -10,30 +10,40 @@ import org.testeditor.web.backend.testexecution.TestExecutorProvider
 import org.testeditor.web.backend.testexecution.common.TestExecutionKey
 
 import static org.assertj.core.api.Assertions.assertThat
+import static org.mockito.ArgumentMatchers.*
+import static org.mockito.Mockito.mock
 import static org.mockito.Mockito.when
+import static org.mockito.Mockito.doReturn
+import static org.mockito.Mockito.spy
+import java.util.Optional
+import java.io.File
+import org.testeditor.web.backend.testexecution.util.serialization.YamlReader
 
 @RunWith(MockitoJUnitRunner)
 class SubStepAggregatingScreenshotFinderTest {
 
 	@Mock TestArtifactRegistryScreenshotFinder mockDelegate
 	@Mock TestExecutionCallTree mockCallTree
-	@Mock TestExecutorProvider mockExecutorProvider
+	@Mock YamlReader mockYamlReader
 
 	@InjectMocks SubStepAggregatingScreenshotFinder finderUnderTest
 
-	// DONOT USE, introduces usage of an element used for InjectMocks but not used anywhere else, makeing the IDE report an annoying warning
-	protected def dummyUsageOfInjected() {
-		mockExecutorProvider
-	}
 	
 	@Test
 	def void retrievesScreenshotsOfSubStepsIfNodeHasNoneOfItsOwn() {
 		// given
-		val key = TestExecutionKey.valueOf('0-0-0-1')
+		val key = spy(TestExecutionKey.valueOf('0-0-0-1'))
 		val childKeys = #['0-0-0-2', '0-0-0-3', '0-0-0-4'].map[TestExecutionKey.valueOf(it)]
+		
+		doReturn(key).when(key).deriveWithSuiteRunId
+		doReturn(Optional.of(mock(File))).when(key).getLatestCallTree(any)
+		
+		when(mockYamlReader.readYaml(any(File))).thenReturn(#{})
+		
 		when(mockDelegate.getScreenshotPathsForTestStep(key)).thenReturn(#[])
 		childKeys.forEach[when(mockDelegate.getScreenshotPathsForTestStep(it)).thenReturn(#['''path/to/screenshot-«callTreeId».png'''])]
-		when(mockCallTree.getDescendantsKeys(key)).thenReturn(childKeys)
+		
+		when(mockCallTree.getDescendantsKeys(eq(key), any)).thenReturn(childKeys)
 
 		// when
 		val actualScreenshots = finderUnderTest.getScreenshotPathsForTestStep(key)


### PR DESCRIPTION
The main objective of this PR is to remove the dependency of `WebApi` on `TestProcessExecution`, in particular `TestSuiteResource`'s dependency on `TestExecutorProvider`. (The latter has been achieved, the former not yet.)

To this end, a series of refactorings have been done, to create a path from `WebApi` to `TestProcessExecution` only through `TestExecutionManager`, `WorkerProvider`, and `Worker`. The refactoring with the biggest impact was that of `TestExecutionCallTree`, which was stateful, inherently unsafe for multi-threaded use, in generally ugly.

Newly introduced is `TestJobStore`, meant to centralize access to jobs that have already been executed. A `TestExecutionManager` may direct inqueries about jobs to either a `TestJobStore` or a `Worker`, depending on whether the job is still running or has already been completed.