### PR TITLE
delete '-d' flag from xvfb-run again

### DIFF
--- a/src/main/java/org/testeditor/web/backend/testexecution/TestExecutorProvider.xtend
+++ b/src/main/java/org/testeditor/web/backend/testexecution/TestExecutorProvider.xtend
@@ -222,7 +222,7 @@ class TestExecutorProvider {
 	
 	private def String[] withEnclosingCommands(String gradleTestCommandLine) {
 		if (System.getenv('TRAVIS').isNullOrEmpty) {
-			return #[whichNice, '-n', '10', whichXvfbrun, '-d', '-e', 'xvfb.error.log', '--server-args=-screen 0 1920x1080x16', whichSh, '-c',
+			return #[whichNice, '-n', '10', whichXvfbrun, '-e', 'xvfb.error.log', '--server-args=-screen 0 1920x1080x16', whichSh, '-c',
 				gradleTestCommandLine]
 		} else {
 			return #[whichSh, '-c', gradleTestCommandLine]


### PR DESCRIPTION
Like in Pull-Request #14 mentioned, the flag '-d' was added to the xvfb-run, but this leads to an exception during test execution on deployed systems, because the underlying docker image for the container is ubuntu with an older xvfb version [2:1.20.4-1] (see https://github.com/test-editor/test-editor-testexecution/blob/master/Dockerfile - openjdk:10-jdk which is based on 'Debian GNU/Linux buster/sid') , which does not support this flag. So removing this flag will result again in failures  during integration tests which, when run locally, fail due to xvfb being unable to allocate a display number, but the the test-execution on deployed-systems will work as before.